### PR TITLE
Use "prepublish" instead of "prepublishOnly"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "buildScss": "node-sass ./src/sass/cookie-policy.scss --include-path node_modules --output-style compressed --output build/css",
     "buildJs": "babel --presets minify ./src/js/cookie-policy.js --out-dir ./build/js/",
     "build": "npm run test && npm run buildScss && npm run buildJs",
-    "prepublishOnly": "npm run build",
+    "prepublish": "npm run build",
     "watch": "npm-watch"
   }
 }


### PR DESCRIPTION
"prepublishOnly" is ignored by NPM <v4. Unfortunately, the
NPM in Ubuntu sources is 3.5.2, so it's quite likely
that "prepublishOnly" would be ignored when people run
"npm publish", which defeats its whole point.

"prepublish" is less than ideal because it's run *after* "npm install"
as well as *before* "npm publish" (god, I know). But in this case
that's probably acceptable.