### PR TITLE
Improve Vanilla include

### DIFF
--- a/src/js/cookie-policy.js
+++ b/src/js/cookie-policy.js
@@ -22,25 +22,27 @@ cpNs.cookiePolicy = (function() {
       let content = options.content;
       let duration = options.duration;
       let start = `
-        <dialog
-          tabindex="0"
-          open="open"
-          role="alertdialog"
-          class="p-notification p-notification--cookie-policy"
-          aria-labelledby="cookie-policy-title"
-          aria-describedby="cookie-policy-content">
-          <h1 id="cookie-policy-title" class="u-off-screen">
-            Cookie policy notification
-          </h1>
-          <span class="p-notification__content"
-            id="cookie-policy-content"
-            role="document"
-            tabindex="0">`;
+        <div class="cookie-policy">
+          <dialog
+            tabindex="0"
+            open="open"
+            role="alertdialog"
+            class="p-notification p-notification--cookie-policy"
+            aria-labelledby="cookie-policy-title"
+            aria-describedby="cookie-policy-content">
+            <h1 id="cookie-policy-title" class="u-off-screen">
+              Cookie policy notification
+            </h1>
+            <span class="p-notification__content"
+              id="cookie-policy-content"
+              role="document"
+              tabindex="0">`;
       let end = `
-            <button class="p-notification__close js-close"
-               aria-label="Close this cookie policy notification">Close</button>
-          </span>
-        </dialog>`;
+              <button class="p-notification__close js-close"
+                aria-label="Close this cookie policy notification">Close</button>
+            </span>
+          </dialog>
+        </div>`;
       if (!content) {
         content = `We use cookies to improve your experience. By your continued
           use of this site you accept such use.`;

--- a/src/sass/_base-typography.scss
+++ b/src/sass/_base-typography.scss
@@ -1,0 +1,19 @@
+%bold {
+  font-weight: 400;
+}
+
+%default-text {
+  line-height: map-get($line-heights, default-text);
+  margin-bottom: map-get($sp-after, default-text) - map-get($nudges, nudge--p);
+  margin-top: 0;
+  padding-top: map-get($nudges, nudge--p);
+}
+
+%small-text {
+  font-size: pow($ms-ratio, -1) * 1rem;
+  line-height: map-get($line-heights, small);
+  margin-bottom: map-get($sp-after, small) +
+    map-get($line-heights, default-text) - map-get($line-heights, small) -
+    map-get($nudges, nudge--small);
+  padding-top: map-get($nudges, nudge--small);
+}

--- a/src/sass/_base-typography.scss
+++ b/src/sass/_base-typography.scss
@@ -12,8 +12,6 @@
 %small-text {
   font-size: pow($ms-ratio, -1) * 1rem;
   line-height: map-get($line-heights, small);
-  margin-bottom: map-get($sp-after, small) +
-    map-get($line-heights, default-text) - map-get($line-heights, small) -
-    map-get($nudges, nudge--small);
+  margin-bottom: map-get($sp-after, small);
   padding-top: map-get($nudges, nudge--small);
 }

--- a/src/sass/_patterns-notification.scss
+++ b/src/sass/_patterns-notification.scss
@@ -2,7 +2,6 @@
   $asset-path: 'https://assets.ubuntu.com/v1/';
 
   .p-notification--cookie-policy {
-    @include vf-p-notification;
     bottom: 0;
     box-sizing: border-box;
     border: 0;
@@ -35,6 +34,7 @@
         background-position: center;
         background-repeat: no-repeat;
         background-size: 1rem;
+        border: 0;
         cursor: pointer;
         height: 1rem;
         padding: 1rem;

--- a/src/sass/_patterns-notification.scss
+++ b/src/sass/_patterns-notification.scss
@@ -35,7 +35,6 @@
         background-position: center;
         background-repeat: no-repeat;
         background-size: 1rem;
-        border: 0;
         cursor: pointer;
         height: 1rem;
         padding: 1rem;

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -7,7 +7,8 @@
 
 // Include all the CSS
 .cookie-policy {
-  @include vf-b-placeholders;
   @include vf-u-off-screen;
+  @include vf-b-placeholders;
+  @include vf-p-notification;
   @include cookie-p-notification;
 }

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -1,11 +1,13 @@
 // Vanilla components
 @import 'vanilla-framework/scss/vanilla';
-@include vf-u-off-screen;
-@include vf-base;
-@include vf-p-notification;
 
 // Patterns
+@import 'base-typography';
 @import 'patterns-notification';
 
 // Include all the CSS
-@include cookie-p-notification;
+.cookie-policy {
+  @include vf-b-placeholders;
+  @include vf-u-off-screen;
+  @include cookie-p-notification;
+}


### PR DESCRIPTION
## Done
Scoped the styling to just the component. Reduced the styling included from Vanilla to just the patterns needed.

**Due to some issues in Vanilla I have had to bring over a few placeholders**

## QA
- Run `npm run build`
- Open index.html
- Clear your cookies and refresh
- Check that the cookie loads correctly
- See that the CSS is 8kb instead of 220kb