### PR TITLE
Improve publish workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "buildScss": "node-sass ./src/sass/cookie-policy.scss --include-path node_modules --output-style compressed --output build/css",
     "buildJs": "rollup -c",
     "build": "npm run clean && npm run test && npm run buildScss && npm run buildJs",
-    "postpublish": "git push origin --all; git push origin --tags",
     "prepublish": "npm run build",
     "preversion": "npm test",
     "watch": "npm-watch"

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "npm-watch": "0.6.0",
     "prettier": "1.17.0",
     "pretty-quick": "1.10.0",
-    "sass-lint": "1.13.1"
-  },
-  "dependencies": {
+    "sass-lint": "1.13.1",
     "@babel/core": "7.4.4",
     "node-sass": "4.12.0",
     "rollup": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "buildJs": "rollup -c",
     "build": "npm run clean && npm run test && npm run buildScss && npm run buildJs",
     "prepublish": "npm run build",
+    "preversion": "npm test",
     "watch": "npm-watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "buildScss": "node-sass ./src/sass/cookie-policy.scss --include-path node_modules --output-style compressed --output build/css",
     "buildJs": "rollup -c",
     "build": "npm run clean && npm run test && npm run buildScss && npm run buildJs",
-    "prepublish": "npm run build",
+    "prepublishonly": "npm run build",
     "preversion": "npm test",
     "watch": "npm-watch"
   }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "buildScss": "node-sass ./src/sass/cookie-policy.scss --include-path node_modules --output-style compressed --output build/css",
     "buildJs": "rollup -c",
     "build": "npm run clean && npm run test && npm run buildScss && npm run buildJs",
+    "postpublish": "git push origin --all; git push origin --tags",
     "prepublish": "npm run build",
     "preversion": "npm test",
     "watch": "npm-watch"


### PR DESCRIPTION
Add a couple of steps to improve the resilience of publishing process

- Add step so that a user can't bump the version with failing tests
- Move dependencies into devDependencies