### PR TITLE
add babel/preset-env, to transpile to IE11 friendly js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "exclude": ["node_modules/**"]
+  "exclude": ["node_modules/**"],
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "browsers": ["last 2 versions"]
+      },
+      "modules": false
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
   },
   "homepage": "https://github.com/canonical-web-and-design/cookie-policy#readme",
   "devDependencies": {
+    "@babel/core": "7.8.4",
+    "@babel/preset-env": "^7.8.4",
     "eslint": "6.8.0",
     "husky": "4.2.1",
+    "node-sass": "4.13.1",
     "npm-watch": "0.6.0",
     "prettier": "1.19.1",
     "pretty-quick": "2.0.1",
-    "sass-lint": "1.13.1",
-    "@babel/core": "7.8.4",
-    "node-sass": "4.13.1",
     "rollup": "1.31.0",
     "rollup-plugin-babel": "4.3.3",
     "rollup-plugin-terser": "5.2.0",
+    "sass-lint": "1.13.1",
     "vanilla-framework": "2.6.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",


### PR DESCRIPTION
## Done

This is part of the work being done to [make forms work on u.c in IE11](https://github.com/canonical-web-and-design/ubuntu.com/issues/6656); that project imports this one, and the ES6 syntax in this one breaks that one in IE11.

## QA

- On the master branch, run `npm install` and `npm run build`
- Check /build/js/cookie-policy.js, search for "const", "let" or "=>" and see that there a few instances of each
- Checkout this branch, run `npm install` and `npm run build`
- Check /build/js/cookie-policy.js, search for "const", "let" or "=>" and see that you come up empty handed