### PR TITLE
Stop this module loading fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,6 @@
     <meta name="description" content="Canonical cookie policy demo" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
-      href="https://fonts.googleapis.com/css?family=Ubuntu:400,300"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
       rel="stylesheet"
       type="text/css"
       media="screen"
@@ -158,7 +153,6 @@
       var options = {
         content:
           'We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself.',
-        duration: 20000,
       };
       cpNs.cookiePolicy(options);
     </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -2,10 +2,9 @@
 @import 'vanilla-framework/scss/vanilla';
 
 // Include base Vanilla styles
-@include vf-base;
+@include vf-b-placeholders;
 
 // Patterns
-@import 'base-typography';
 @import 'patterns-notification';
 
 // Include all the CSS


### PR DESCRIPTION
## Done
- Restructured the Vanilla import to not include the base typography but just the base placeholders. 
- Removed the font loading from google in the example as it makes the test false. 
- Removed the timer on the cookie policy as its easier to test without it.
- Bumped the version for release.

## QA
- Pull this branch
- Run `rm -rf node_modules`
- Run `npm install`
- Run `npm run build`
- Then open the index.html and see the cookie policy looks ok

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/65