### PR TITLE
Add affordance for old cookie values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,5 +21,11 @@ export const getCookie = () => {
 };
 
 export const preferenceNotSelected = () => {
-  return getCookie('_cookies_accepted') ? false : true;
+  const cookieValue = getCookie('_cookies_accepted');
+  // Skip a value of "true" to override old existing cookies
+  if (cookieValue && cookieValue != 'true') {
+    return false;
+  } else {
+    return true;
+  }
 };


### PR DESCRIPTION
## Done
Not only check the existence of the cookie but execute the value "true" to invoke the policy notification with legacy cookies.

## QA
- Pull down the branch
- Run `npm run build`
- Open index.html in your browser
- Accept the policy and check the cookie `_cookies_accepted` is set to `all`.
- Refresh and see the policy is not displayed again
- Change the value of the cookie to "true" in the inspector
- Refresh and see that invokes the policy panel
- Make another selection and see the value represents your choice

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/73