### PR TITLE
Prevent default action on revoke link

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
     <p>
       This is the demo of the global navigation project for Canonicals websites.
     </p>
-    <button href="" class="js-revoke-cookie-manager">
+    <a href="" class="js-revoke-cookie-manager">
       Revoke cookie manager
-    </button>
+    </a>
     <script src="build/js/cookie-policy.js"></script>
     <script>
       cpNs.cookiePolicy();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,7 +5,11 @@ import { preferenceNotSelected } from './utils.js';
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
 
-  const renderNotification = function () {
+  const renderNotification = function (e) {
+    if (e) {
+      e.preventDefault();
+    }
+
     if (cookiePolicyContainer === null) {
       cookiePolicyContainer = document.createElement('div');
       cookiePolicyContainer.classList.add('cookie-policy');


### PR DESCRIPTION
## QA
- Run `npm run build` and visit index.html
- Click the "Revoke cookie manager" link
- See it Revokes the manager.