### PR TITLE
Expire the cookie after a year instead of a day

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,6 +1,6 @@
 export const setCookie = (value) => {
   const d = new Date();
-  d.setTime(d.getTime() + 24 * 60 * 60 * 1000);
+  d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000);
   const expires = 'expires=' + d.toUTCString();
   const samesite = 'samesite=lax;';
   document.cookie =


### PR DESCRIPTION
## QA
- Run `npm run build`
- Open index.html
- Clear cookies and refresh
- Click accept all
- See the `_cookies_accepted` expires in a year

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/87