### PR TITLE
Improve iOS Safari UI

### DIFF
--- a/src/sass/_patterns-modal.scss
+++ b/src/sass/_patterns-modal.scss
@@ -1,0 +1,15 @@
+@mixin cookie-p-modal {
+  .p-modal {
+    height: auto;
+    width: auto;
+
+    &__dialog {
+      overflow: auto;
+      margin-bottom: 2rem !important;
+    }
+
+    button {
+      box-sizing: border-box;
+    }
+  }
+}

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -6,6 +6,7 @@
 
 // Patterns
 @import 'patterns-notification';
+@import 'patterns-modal';
 
 // Include all the CSS
 .cookie-policy {
@@ -22,8 +23,5 @@
   @include vf-u-off-screen;
   @include vf-u-floats;
   @include cookie-p-notification;
-
-  .p-modal__dialog {
-    overflow: auto;
-  }
+  @include cookie-p-modal;
 }


### PR DESCRIPTION
## Done
- Added padding at the bottom of the modal
- Improved all-round modal styling behaviour on small screens

## QA
- Run `npm install` and `npm run build`
- Open index.html and simulate a small screen
- Open the manager and check it looks ok
- Scoll to the bottom and see there is space for Apple to get in the way :smile: 

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/89