### PR TITLE
Add path when creating the cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -3,8 +3,9 @@ export const setCookie = (value) => {
   d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000);
   const expires = 'expires=' + d.toUTCString();
   const samesite = 'samesite=lax;';
+  const path = 'path=/;';
   document.cookie =
-    '_cookies_accepted=' + value + '; ' + expires + '; ' + samesite;
+    '_cookies_accepted=' + value + '; ' + expires + '; ' + samesite + path;
   if (enabledTracking(value)) {
     pushPageview();
   }


### PR DESCRIPTION
## Done
Set the `path` to root when creating the cookie.

## QA
- Run `npm build`
- Run `python -m SimpleHTTPServer`
- Go to http://localhost:8000
- Click accept all 
- Go to the cookie in the inspector
- See the path is set to "/"

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/94