### PR TITLE
Ignore old _cookie_accepted values

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -14,16 +14,19 @@ export const setCookie = (value) => {
 export const getCookie = () => {
   const toMatch = '_cookies_accepted=';
   const splitArray = document.cookie.split(';');
+  let cookieValue = '';
+  let currentCookieValue = '';
   for (let i = 0; i < splitArray.length; i++) {
     let cookie = splitArray[i];
     while (cookie.charAt(0) == ' ') {
       cookie = cookie.substring(1);
     }
-    if (cookie.indexOf(toMatch) === 0) {
-      return cookie.substring(toMatch.length, cookie.length);
+    currentCookieValue = cookie.substring(toMatch.length, cookie.length);
+    if (cookie.indexOf(toMatch) === 0 && currentCookieValue !== 'true') {
+      cookieValue = currentCookieValue;
     }
   }
-  return '';
+  return cookieValue;
 };
 
 export const preferenceNotSelected = () => {


### PR DESCRIPTION
## Done
Previously the `getCookies` function would return the value of the first `_cookies_accepted` cookie it finds. We now loop through all of them and ignore ones with the value of `true`. Which is the old value which is no longer used.

## QA
- Create a new root directory in the project. I called mine "sec".
- Copy the index.html to the new sec directory
- Open /sec/index.html and change all the include paths to be frrom root by adding a `/` in front
- Run `npm install` 
- Run `npm run build`
- Set up a simple server with `python -m SimpleHTTPServer` just to be sure, some browsers are funny about local cookies
- Open the localhost and port the server is running on
- Clear cookies and then refresh
- Go to /sec
- Accept all cookies by hitting the green button
- Open the inspector and view cookies
- Edit the value of the cookie from `all` to `true` and the path to /sec to mimic an old cookie
- Now go to root `/` in the browser and you should still see the cookie policy
- Accept all cookies again and you should now have two cookies with different paths and values
- Go back to /sec in the browser and see you don't get the cookie policy because that the root cookie is the one being used.

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8691