### PR TITLE
Add translation to Chinese based on document lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ To build the JS and CSS into the build folder, run:
 npm run build
 ```
 
-You can view the build files in action by opening the `index.html` in the root
-of this project.
+You can view the build files in action by running:
+
+```
+python -m SimpleHTTPServer
+```
+
+And, visiting http://0.0.0.0:8000/
 
 ### Hacking
 

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,23 +1,104 @@
 export const controlsContent = [
   {
     id: 'essential',
-    title: 'Essential',
-    description:
-      "Enables the site's core functionality, such as navigation, access to secure areas, video players and payments. The site cannot function properly without these cookies; they can only be disabled by changing your browser preferences.",
     showSwitcher: false,
+    content: {
+      default: {
+        title: 'Essential',
+        description:
+          "Enables the site's core functionality, such as navigation, access to secure areas, video players and payments. The site cannot function properly without these cookies; they can only be disabled by changing your browser preferences.",
+      },
+      zh: {
+        title: '必要性',
+        description:
+          '启用网站核心功能，例如导航，访问安全区域，视频播放器和支付。没有这些cookie网站不能正常工作；它们仅可通过修改浏览器偏好设置禁用。',
+      },
+    },
   },
   {
     id: 'performance',
-    title: 'Performance',
-    description:
-      'Collects information on site usage, for example, which pages are most frequently visited.',
     showSwitcher: true,
+    content: {
+      default: {
+        title: 'Performance',
+        description:
+          'Collects information on site usage, for example, which pages are most frequently visited.',
+      },
+      zh: {
+        title: '表现性',
+        description: '网站使用信息收集，例如哪些网页被频繁访问。',
+      },
+    },
   },
   {
     id: 'functionality',
-    title: 'Functionality',
-    description:
-      'Recognises you when you return to our site. This enables us to personalise content, greet you by name, remember your preferences, and helps you share pages on social networks.',
     showSwitcher: true,
+    content: {
+      default: {
+        title: 'Functionality',
+        description:
+          'Recognises you when you return to our site. This enables us to personalise content, greet you by name, remember your preferences, and helps you share pages on social networks.',
+      },
+      zh: {
+        title: '功能性',
+        description:
+          '当你返回到我们网站时能识别您。这使得我们能个性化内容，欢迎您，记住您的偏好设置，以及帮助您分享网页到社交媒体。',
+      },
+    },
   },
 ];
+
+export const content = {
+  default: {
+    notification: {
+      title: 'Your tracker settings',
+      body1:
+        'We use cookies and similar methods to recognise visitors and remember preferences. We also use them to measure campaign effectiveness and analyse site traffic.',
+      body2:
+        'By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties.',
+      body3:
+        'For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy#cookies">cookie policy</a>.',
+      buttonAccept: 'Accept all and visit site',
+      buttonManage: 'Manage your tracker settings',
+    },
+    manager: {
+      title: 'Tracking choices',
+      body1:
+        'We use cookies to recognise visitors and remember your preferences.',
+      body2:
+        'They enhance user experience, personalise content and ads, provide social media features, measure campaign effectiveness, and analyse site traffic.',
+      body3:
+        'Select the types of trackers you consent to, both by us, and third parties.',
+      body4:
+        'Learn more at <a href="https://ubuntu.com/legal/data-privacy#cookies">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
+      acceptAll: 'Accept all',
+      acceptAllHelp: 'This will switch all toggles "ON".',
+      SavePreferences: 'Save preferences',
+    },
+  },
+
+  zh: {
+    notification: {
+      title: '您的追踪器设置',
+      body1:
+        '我们使用cookie和相似的方法来识别访问者和记住偏好设置。我们也用它们来衡量活动的效果和网站流量分析。',
+      body2: '选择”接受“，您同意我们和受信的第三方来使用这些方式。',
+      body3:
+        '更多内容或者随时地变更您的同意选择，请点击我们的 <a href="https://ubuntu.com/legal/data-privacy#cookies">cookie策略</a>.',
+      buttonAccept: '接受全部和访问网站',
+      buttonManage: '管理您的追踪器设置',
+    },
+    manager: {
+      title: '追踪选项',
+      body1: '我们使用cookie来识别访问者和记住您的偏好设置',
+      body2:
+        '它们增强用户体验，使内容和广告个性化，提供社交媒体功能，衡量活动效果和网站流量分析。',
+      body3: '选择您同意授予我们和受信的第三方的追踪类型。',
+      body4:
+        '点击<a href="https://ubuntu.com/legal/data-privacy#cookies">数据隐私：cookie策略</a>了解更多，您可以在网站底部随时更改您的选择。',
+      acceptAll: '接受全部',
+      acceptAllHelp: '这将把全部开关变为”开启“。',
+      SavePreferences: '保存偏好设置',
+    },
+  },
+};

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -1,8 +1,9 @@
 export class Control {
-  constructor(details, container) {
+  constructor(details, container, language) {
+    this.language = language;
     this.id = details.id;
-    this.title = details.title;
-    this.description = details.description;
+    this.title = details.content[this.language].title;
+    this.description = details.content[this.language].description;
     this.showSwitcher = details.showSwitcher;
     this.container = container;
     this.element;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,6 +4,7 @@ import { preferenceNotSelected } from './utils.js';
 
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
+  let language = document.documentElement.lang;
 
   const renderNotification = function (e) {
     if (e) {
@@ -19,13 +20,13 @@ export const cookiePolicy = (callback = null) => {
         renderManager,
         close
       );
-      notifiation.render();
+      notifiation.render(language);
     }
   };
 
   const renderManager = function () {
     const manager = new Manager(cookiePolicyContainer, close);
-    manager.render();
+    manager.render(language);
   };
 
   const close = function () {

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -1,4 +1,4 @@
-import { setCookie } from './utils.js';
+import { setCookie, getContent } from './utils.js';
 import { Control } from './control.js';
 import { controlsContent } from './content.js';
 
@@ -7,30 +7,36 @@ export class Manager {
     this.container = container;
     this.controlsStore = [];
     this.destroyComponent = destroyComponent;
-    this.content = `
-      <div class="p-modal" id="modal">
-        <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
-          <header class="p-modal__header">
-            <h2 class="p-modal__title" id="modal-title">Tracking choices</h2>
-          </header>
-          <p id="modal-description">We use cookies to recognise visitors and remember your preferences.</p>
-          <p>They enhance user experience, personalise content and ads, provide social media features, measure campaign effectiveness, and analyse site traffic.</p>
-          <p>Select the types of trackers you consent to, both by us, and third parties.</p>
-          <p>Learn more at <a href="https://ubuntu.com/legal/data-privacy#cookies">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.</p>
-          <p><button class="p-button--positive u-no-margin--bottom js-close">Accept all</button></p>
-          <p>This will switch all toggles "ON".</p>
-          <hr />
-          <div class="controls"></div>
-          <button class="p-button--neutral js-save-preferences">Save preferences</button>
-        </div>
-      </div>`;
   }
 
-  render() {
-    this.container.innerHTML = this.content;
+  getManagerMarkup(language) {
+    const managerContent = getContent(language).manager;
+    const manager = `
+    <div class="p-modal" id="modal">
+    <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+      <header class="p-modal__header">
+        <h2 class="p-modal__title" id="modal-title">${managerContent.title}</h2>
+      </header>
+      <p id="modal-description">${managerContent.body1}</p>
+      <p>${managerContent.body2}</p>
+      <p>${managerContent.body3}</p>
+      <p>${managerContent.body4}</p>
+      <p><button class="p-button--positive u-no-margin--bottom js-close">${managerContent.acceptAll}</button></p>
+      <p>${managerContent.acceptAllHelp}</p>
+      <hr />
+      <div class="controls"></div>
+      <button class="p-button--neutral js-save-preferences">${managerContent.SavePreferences}</button>
+    </div>
+  </div>`;
+
+    return manager;
+  }
+
+  render(language) {
+    this.container.innerHTML = this.getManagerMarkup(language);
     const controlsContainer = this.container.querySelector('.controls');
     controlsContent.forEach((controlDetails) => {
-      const control = new Control(controlDetails, controlsContainer);
+      const control = new Control(controlDetails, controlsContainer, language);
       this.controlsStore.push(control);
     });
     this.initaliseListeners();

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -1,11 +1,16 @@
-import { setCookie } from './utils.js';
+import { setCookie, getContent } from './utils.js';
+import { content } from './content.js';
 
 export class Notification {
   constructor(container, renderManager, destroyComponent) {
     this.container = container;
     this.renderManager = renderManager;
     this.destroyComponent = destroyComponent;
-    this.content = `
+  }
+
+  getNotificationMarkup(language) {
+    const notificationContent = getContent(language);
+    const notification = `
       <dialog
         tabindex="0"
         open="open"
@@ -13,28 +18,27 @@ export class Notification {
         class="p-notification p-notification--cookie-policy"
         aria-labelledby="cookie-policy-title"
         aria-describedby="cookie-policy-content">
-        <h1 id="cookie-policy-title" class="u-off-screen">
-          Cookie policy notification
-        </h1>
         <span class="p-notification__content"
           id="cookie-policy-content"
           role="document"
           tabindex="0">
-          <h1 class="p-heading--four">Your tracker settings</h1>
+          <h1 id="cookie-policy-title" class="p-heading--four">${notificationContent.notification.title}</h1>
           <hr />
-          <p>We use cookies and similar methods to recognise visitors and remember preferences. We also use them to measure campaign effectiveness and analyse site traffic.</p>
-          <p>By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties.</p>
-          <p>For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy#cookies">cookie policy</a>.</p>
+          <p>${notificationContent.notification.body1}</p>
+          <p>${notificationContent.notification.body2}</p>
+          <p>${notificationContent.notification.body3}</p>
           <p class="u-no-margin--bottom">
-            <button class="p-button--positive js-close">Accept all and visit site</button>
-            <button class="p-button--neutral u-no-margin--bottom js-manage">Manage your tracker settings</button>
+            <button class="p-button--positive js-close">${notificationContent.notification.buttonAccept}</button>
+            <button class="p-button--neutral u-no-margin--bottom js-manage">${notificationContent.notification.buttonManage}</button>
           </p>
         </span>
       </dialog>`;
+
+    return notification;
   }
 
-  render() {
-    this.container.innerHTML = this.content;
+  render(language) {
+    this.container.innerHTML = this.getNotificationMarkup(language);
     this.initaliseListeners();
   }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,5 @@
+import { content } from './content.js';
+
 export const setCookie = (value) => {
   const d = new Date();
   d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000);
@@ -36,6 +38,14 @@ export const preferenceNotSelected = () => {
     return false;
   } else {
     return true;
+  }
+};
+
+export const getContent = (language) => {
+  if (content[language]) {
+    return content[language];
+  } else {
+    return content['default'];
   }
 };
 

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html class="no-js" lang="">
+<html class="no-js" lang="zh">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    <title>Canonical cookie policy demo</title>
+    <title>Canonical cookie policy demo in Chinese</title>
     <link
       rel="shortcut icon"
       href="https://assets.ubuntu.com/v1/0843d517-favicon.ico"
@@ -31,14 +31,10 @@
   </head>
 
   <body>
-    <h1>Page content</h1>
-    <p>
-      This is the demo of the cookie manager project for Canonicals websites.
-    </p>
-    <p>
-      <a href="" class="js-revoke-cookie-manager"> Revoke cookie manager </a>
-    </p>
-    <p><a href="/zh"> Chinese version </a></p>
+    <h1>The Chinese cookie manager</h1>
+    <p>这是Canonicals网站的cookie管理器项目的演示。</p>
+    <a href="" class="js-revoke-cookie-manager"> 撤消cookie管理器 </a>
+    <p><a href="/"> English version </a></p>
     <script src="/build/js/cookie-policy.js"></script>
     <script>
       cpNs.cookiePolicy();


### PR DESCRIPTION
## Done
- Added translation feature
- Added all the zh translations
- Added a zh demo for local testing
- Updated the README to recommend running a simple server

## QA
- Run `npm install`
- Run `npm run build`
- Run `python -m SimpleHTTPServer`
- Visit http://localhost:8000
- Check everything works as before
- Click the link to the Chinese version
- Check everything works and matches [the copy doc](https://docs.google.com/document/d/1WrpaKvSLbpN5ejgA5FRMLl9rzn9Gaq4AIGPCnSu3eHo/edit#)

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/98