### PR TITLE
(feat): ability to disable manager with a query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ or
 <a href="" class="js-revoke-cookie-manager"Revoke cookie manager</a>
 ```
 
+### Visiting a page with tracker disabled
+
+If you add the query `?cp=hide` to any URL the cookie policy will not be rendered. The main use case is to visit the policy page without the modal blocking the content.
+
 ### Callback hook
 
 You can set up the cookie policy with a callback when a preference is selected.

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -138,7 +138,7 @@ export const content = {
       body3:
         '当社および第三者によるトラッキング機能のタイプから、お客様が同意されるものをお選びください。',
       body4:
-        '詳細は、<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">データプライバシー：クッキーに関するポリシー</a>をご覧ください。お客様が選んだ設定は、本サイトの下部からいつでも変更できます。',
+        '詳細は、<a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">データプライバシー：クッキーに関するポリシー</a>をご覧ください。お客様が選んだ設定は、本サイトの下部からいつでも変更できます。',
       acceptAll: 'すべて同意',
       acceptAllHelp: '同意されるとすべての設定が「ON」に切り替わります。',
       SavePreferences: '設定を保存',

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -72,7 +72,7 @@ export const content = {
       body2:
         'By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties.',
       body3:
-        'For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide?cp=hide">cookie policy</a>.',
+        'For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">cookie policy</a>.',
       buttonAccept: 'Accept all and visit site',
       buttonManage: 'Manage your tracker settings',
     },

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -85,7 +85,7 @@ export const content = {
       body3:
         'Select the types of trackers you consent to, both by us, and third parties.',
       body4:
-        'Learn more at <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
+        'Learn more at <a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
       acceptAll: 'Accept all',
       acceptAllHelp: 'This will switch all toggles "ON".',
       SavePreferences: 'Save preferences',

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -110,7 +110,7 @@ export const content = {
         '它们增强用户体验，使内容和广告个性化，提供社交媒体功能，衡量活动效果和网站流量分析。',
       body3: '选择您同意授予我们和受信的第三方的追踪类型。',
       body4:
-        '点击<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">数据隐私：cookie策略</a>了解更多，您可以在网站底部随时更改您的选择。',
+        '点击<a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">数据隐私：cookie策略</a>了解更多，您可以在网站底部随时更改您的选择。',
       acceptAll: '接受全部',
       acceptAllHelp: '这将把全部开关变为”开启“。',
       SavePreferences: '保存偏好设置',

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -72,7 +72,7 @@ export const content = {
       body2:
         'By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties.',
       body3:
-        'For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy#cookies">cookie policy</a>.',
+        'For further details or to change your consent choices at any time see our <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide?cp=hide">cookie policy</a>.',
       buttonAccept: 'Accept all and visit site',
       buttonManage: 'Manage your tracker settings',
     },
@@ -85,7 +85,7 @@ export const content = {
       body3:
         'Select the types of trackers you consent to, both by us, and third parties.',
       body4:
-        'Learn more at <a href="https://ubuntu.com/legal/data-privacy#cookies">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
+        'Learn more at <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
       acceptAll: 'Accept all',
       acceptAllHelp: 'This will switch all toggles "ON".',
       SavePreferences: 'Save preferences',
@@ -99,7 +99,7 @@ export const content = {
         '我们使用cookie和相似的方法来识别访问者和记住偏好设置。我们也用它们来衡量活动的效果和网站流量分析。',
       body2: '选择”接受“，您同意我们和受信的第三方来使用这些方式。',
       body3:
-        '更多内容或者随时地变更您的同意选择，请点击我们的 <a href="https://ubuntu.com/legal/data-privacy#cookies">cookie策略</a>.',
+        '更多内容或者随时地变更您的同意选择，请点击我们的 <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">cookie策略</a>.',
       buttonAccept: '接受全部和访问网站',
       buttonManage: '管理您的追踪器设置',
     },
@@ -110,7 +110,7 @@ export const content = {
         '它们增强用户体验，使内容和广告个性化，提供社交媒体功能，衡量活动效果和网站流量分析。',
       body3: '选择您同意授予我们和受信的第三方的追踪类型。',
       body4:
-        '点击<a href="https://ubuntu.com/legal/data-privacy#cookies">数据隐私：cookie策略</a>了解更多，您可以在网站底部随时更改您的选择。',
+        '点击<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">数据隐私：cookie策略</a>了解更多，您可以在网站底部随时更改您的选择。',
       acceptAll: '接受全部',
       acceptAllHelp: '这将把全部开关变为”开启“。',
       SavePreferences: '保存偏好设置',
@@ -125,7 +125,7 @@ export const content = {
       body2:
         '「同意」を選択すると、当社および信頼できる第三者による上記の手法の利用に同意したものとみなされます。',
       body3:
-        '詳細または同意の変更については、いつでも当社の<a href="https://ubuntu.com/legal/data-privacy#cookies">クッキーに関するポリシー</a>をご覧になることができます。',
+        '詳細または同意の変更については、いつでも当社の<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">クッキーに関するポリシー</a>をご覧になることができます。',
       buttonAccept: 'すべて同意してサイトにアクセス',
       buttonManage: 'トラッキング機能の設定の管理',
     },
@@ -138,7 +138,7 @@ export const content = {
       body3:
         '当社および第三者によるトラッキング機能のタイプから、お客様が同意されるものをお選びください。',
       body4:
-        '詳細は、<a href="https://ubuntu.com/legal/data-privacy#cookies">データプライバシー：クッキーに関するポリシー</a>をご覧ください。お客様が選んだ設定は、本サイトの下部からいつでも変更できます。',
+        '詳細は、<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">データプライバシー：クッキーに関するポリシー</a>をご覧ください。お客様が選んだ設定は、本サイトの下部からいつでも変更できます。',
       acceptAll: 'すべて同意',
       acceptAllHelp: '同意されるとすべての設定が「ON」に切り替わります。',
       SavePreferences: '設定を保存',

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -125,7 +125,7 @@ export const content = {
       body2:
         '「同意」を選択すると、当社および信頼できる第三者による上記の手法の利用に同意したものとみなされます。',
       body3:
-        '詳細または同意の変更については、いつでも当社の<a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">クッキーに関するポリシー</a>をご覧になることができます。',
+        '詳細または同意の変更については、いつでも当社の<a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">クッキーに関するポリシー</a>をご覧になることができます。',
       buttonAccept: 'すべて同意してサイトにアクセス',
       buttonManage: 'トラッキング機能の設定の管理',
     },

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -99,7 +99,7 @@ export const content = {
         '我们使用cookie和相似的方法来识别访问者和记住偏好设置。我们也用它们来衡量活动的效果和网站流量分析。',
       body2: '选择”接受“，您同意我们和受信的第三方来使用这些方式。',
       body3:
-        '更多内容或者随时地变更您的同意选择，请点击我们的 <a href="https://ubuntu.com/legal/data-privacy#cookies?cp=hide">cookie策略</a>.',
+        '更多内容或者随时地变更您的同意选择，请点击我们的 <a href="https://ubuntu.com/legal/data-privacy?cp=hide#cookies">cookie策略</a>.',
       buttonAccept: '接受全部和访问网站',
       buttonManage: '管理您的追踪器设置',
     },

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,6 @@
 import { Notification } from './notification.js';
 import { Manager } from './manager.js';
-import { preferenceNotSelected } from './utils.js';
+import { preferenceNotSelected, hideSpecified } from './utils.js';
 
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
@@ -43,7 +43,7 @@ export const cookiePolicy = (callback = null) => {
       revokeButton.addEventListener('click', renderNotification);
     }
 
-    if (preferenceNotSelected()) {
+    if (preferenceNotSelected() && !hideSpecified()) {
       renderNotification();
     }
   };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -41,6 +41,17 @@ export const preferenceNotSelected = () => {
   }
 };
 
+export const hideSpecified = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const cpQuery = urlParams.get('cp');
+
+  if (cpQuery === 'hide') {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 export const getContent = (language) => {
   if (content[language]) {
     return content[language];


### PR DESCRIPTION
## Done
The issue was that when you visit the policy page the content is blocked by the modal. This update adds a query param of `cp=hide` to the URL which disabled the modal from rendering. This will allow users to view that page content without opting into tracking but the param is only used in this place case.

## QA
- Run `npm install`
- Run `npm run build`
- Run `npm run serve`
- Visit http://0.0.0.0:8301/
- Open the inspector and clear your cookies
- Then refresh
- You should see the modal
- Click "Manage your tracking settings" to open the manager
- Check the link to the cookie policy has `?cp=hide` at the end of the link
- Change the URL to `http://0.0.0.0:8301/?cp=hide` and hit enter
- You should not have the cookie and also no modal
- Check it works with extra queries 
- Then remove all queries for peace of mind to see the cookie policy modal once more

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/106