### PR TITLE
Focus the modal when it opens

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,28 @@
     </p>
     <p><a href="/zh">Chinese version</a></p>
     <p><a href="/ja">Japanese version</a></p>
+    <br />
+    <h2>Long content that needs to be scrolled</h2>
+    <p style="line-height: 10rem">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque at magna
+      tellus. Vivamus blandit a ante eget imperdiet. Nunc quis interdum sapien,
+      sit amet feugiat odio. Ut erat sem, efficitur eu ante at, mattis lacinia
+      massa. Cras nisl arcu, elementum vitae est ut, scelerisque faucibus nisi.
+      Morbi quis gravida mi. Sed tristique turpis nulla, a porta erat rutrum
+      eget. Ut gravida quis turpis sed posuere. Etiam eu laoreet magna, eget
+      dapibus ipsum. Quisque id arcu ipsum. Nunc facilisis scelerisque libero,
+      in ullamcorper velit venenatis vitae. Aliquam erat volutpat. Cras vitae
+      massa et erat aliquet egestas. Phasellus pharetra ex vitae finibus
+      blandit. Aliquam nec arcu ipsum. Nulla a sapien auctor, bibendum ex vel,
+      suscipit urna. Fusce interdum odio velit, ultrices euismod sapien
+      malesuada et. Sed quis dictum eros, sed dapibus nibh. Quisque quis sem
+      quis lorem varius blandit. Sed ac facilisis ante. Cras ante urna, placerat
+      quis eros at, placerat sagittis augue. Integer aliquam leo vitae sapien
+      consequat commodo. Curabitur sit amet purus velit. Proin sagittis cursus
+      vehicula. Donec viverra a magna at consectetur. Mauris eget lorem
+      eleifend, congue magna sit amet, venenatis neque. Phasellus suscipit
+      molestie ipsum, id condimentum elit. Etiam mollis nulla at dictum semper.
+    </p>
     <script src="/build/js/cookie-policy.js"></script>
     <script>
       cpNs.cookiePolicy();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,6 +14,7 @@ export const cookiePolicy = (callback = null) => {
     if (cookiePolicyContainer === null) {
       cookiePolicyContainer = document.createElement('div');
       cookiePolicyContainer.classList.add('cookie-policy');
+      document.body.classList.add('u-scroll-lock');
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -34,6 +35,7 @@ export const cookiePolicy = (callback = null) => {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
+    document.body.classList.remove('u-scroll-lock');
     cookiePolicyContainer = null;
   };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -12,8 +12,9 @@ export const cookiePolicy = (callback = null) => {
     }
 
     if (cookiePolicyContainer === null) {
-      cookiePolicyContainer = document.createElement('div');
+      cookiePolicyContainer = document.createElement('dialog');
       cookiePolicyContainer.classList.add('cookie-policy');
+      cookiePolicyContainer.setAttribute('open', true);
       document.body.classList.add('u-scroll-lock');
       document.body.setAttribute('aria-hidden', true);
       document.body.appendChild(cookiePolicyContainer);
@@ -23,6 +24,7 @@ export const cookiePolicy = (callback = null) => {
         close
       );
       notifiation.render(language);
+      document.getElementById('cookie-policy-button-accept').focus();
     }
   };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,6 +15,7 @@ export const cookiePolicy = (callback = null) => {
       cookiePolicyContainer = document.createElement('div');
       cookiePolicyContainer.classList.add('cookie-policy');
       document.body.classList.add('u-scroll-lock');
+      document.body.setAttribute('aria-hidden', true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -36,6 +37,7 @@ export const cookiePolicy = (callback = null) => {
     }
     document.body.removeChild(cookiePolicyContainer);
     document.body.classList.remove('u-scroll-lock');
+    document.body.removeAttribute('aria-hidden');
     cookiePolicyContainer = null;
   };
 

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -32,11 +32,6 @@ export class Notification {
   render(language) {
     this.container.innerHTML = this.getNotificationMarkup(language);
     this.initaliseListeners();
-    this.container.children[0].children[0].children[1].focus();
-    this.container.children[0].children[0].children[1].setAttribute(
-      'style',
-      'background: purple;'
-    );
   }
 
   initaliseListeners() {

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -20,7 +20,7 @@ export class Notification {
           <p>${notificationContent.notification.body2}</p>
           <p>${notificationContent.notification.body3}</p>
           <p class="u-no-margin--bottom">
-            <button class="p-button--positive js-close">${notificationContent.notification.buttonAccept}</button>
+            <button class="p-button--positive js-close" id="cookie-policy-button-accept">${notificationContent.notification.buttonAccept}</button>
             <button class="p-button--neutral u-no-margin--bottom js-manage">${notificationContent.notification.buttonManage}</button>
           </p>
         </div>
@@ -32,6 +32,11 @@ export class Notification {
   render(language) {
     this.container.innerHTML = this.getNotificationMarkup(language);
     this.initaliseListeners();
+    this.container.children[0].children[0].children[1].focus();
+    this.container.children[0].children[0].children[1].setAttribute(
+      'style',
+      'background: purple;'
+    );
   }
 
   initaliseListeners() {

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -23,3 +23,7 @@
   @include vf-u-floats;
   @include cookie-p-modal;
 }
+
+.u-scroll-lock {
+  overflow: hidden;
+}


### PR DESCRIPTION
# What I did

- Blocked the scroll on the background when the modal is open and hide the background content to screen readers. (And added some text to the demo to test it)
- Turned the container into a `<modal>` element
- Focused the accept button when the modal opens

