### PR TITLE
Remove the scroll locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,7 +15,6 @@ export const cookiePolicy = (callback = null) => {
       cookiePolicyContainer = document.createElement('dialog');
       cookiePolicyContainer.classList.add('cookie-policy');
       cookiePolicyContainer.setAttribute('open', true);
-      document.body.classList.add('u-scroll-lock');
       document.body.setAttribute('aria-hidden', true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
@@ -38,7 +37,6 @@ export const cookiePolicy = (callback = null) => {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
-    document.body.classList.remove('u-scroll-lock');
     document.body.removeAttribute('aria-hidden');
     cookiePolicyContainer = null;
   };

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -23,7 +23,3 @@
   @include vf-u-floats;
   @include cookie-p-modal;
 }
-
-.u-scroll-lock {
-  overflow: hidden;
-}


### PR DESCRIPTION
Remove the scroll locking when the modal is displayed as browser extensions such as "I don't care about cookies" hide the modal. Which leaves the scroll lock on. Discussed here: https://github.com/canonical-web-and-design/charmhub.io/issues/809.

## QA
- Load the example
- Check that when the modal appears there is no `u-scroll-lock` class on the body.

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/113