### PR TITLE
Don't set `aria-hidden` on the `body` tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,7 +15,6 @@ export const cookiePolicy = (callback = null) => {
       cookiePolicyContainer = document.createElement('dialog');
       cookiePolicyContainer.classList.add('cookie-policy');
       cookiePolicyContainer.setAttribute('open', true);
-      document.body.setAttribute('aria-hidden', true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -37,7 +36,6 @@ export const cookiePolicy = (callback = null) => {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
-    document.body.removeAttribute('aria-hidden');
     cookiePolicyContainer = null;
   };
 


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-web-and-design/netplan.io/issues/176

- Removed `aria-hidden` being set on the `body` tag, it was preventing all content, including the cookie policy modal, from being read by screen readers - it should be enough to add `role="dialog"` and set the focus within the dialog, which is already happening (see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role))
- bumped version to 3.3.0

# QA

- Launch a screen reader
  - You can reproduce the steps in the [issue](https://github.com/canonical-web-and-design/netplan.io/issues/176) on Ubuntu by opening system settings -> accessibility -> screen reader: ON
  - Or use [Chrome's Screen Reader extension](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en)
- Pull this branch down, run `npm run serve`
- Visit http://0.0.0.0:8301/
- Hear that the screen reader reads out at least the title of the cookie policy modal and one of the buttons
- You can also test this by going to netplan.io (or any other Canonical site that uses the cookie policy), clearing the cookie policy cookie, reloading the page. The screen reader should read out very little useful information, if anything.
  - you can fix it by inspecting the DOM and removing `aria-hidden` from the `body` tag, then closing the dev tools. This should restore focus to the page. Tab around the modal, nothing will be read out.
