### PR TITLE
Reduce the max-height on the window

### DIFF
--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -1,4 +1,4 @@
-import { setCookie, getContent } from './utils.js';
+import { setCookie, getContent } from "./utils.js";
 
 export class Notification {
   constructor(container, renderManager, destroyComponent) {
@@ -21,7 +21,7 @@ export class Notification {
           <p>${notificationContent.notification.body3}</p>
           <p class="u-no-margin--bottom">
             <button class="p-button--positive js-close" id="cookie-policy-button-accept">${notificationContent.notification.buttonAccept}</button>
-            <button class="p-button--neutral u-no-margin--bottom js-manage">${notificationContent.notification.buttonManage}</button>
+            <button class="p-button--neutral js-manage">${notificationContent.notification.buttonManage}</button>
           </p>
         </div>
       </div>`;
@@ -35,13 +35,13 @@ export class Notification {
   }
 
   initaliseListeners() {
-    this.container.querySelector('.js-close').addEventListener('click', (e) => {
-      setCookie('all');
+    this.container.querySelector(".js-close").addEventListener("click", (e) => {
+      setCookie("all");
       this.destroyComponent();
     });
     this.container
-      .querySelector('.js-manage')
-      .addEventListener('click', (e) => {
+      .querySelector(".js-manage")
+      .addEventListener("click", (e) => {
         this.renderManager();
       });
   }

--- a/src/sass/_patterns-modal.scss
+++ b/src/sass/_patterns-modal.scss
@@ -4,8 +4,10 @@
     width: auto;
 
     &__dialog {
-      margin-bottom: 2rem !important;
+      margin-bottom: 0 !important;
+      max-height: 80vh;
       overflow: auto;
+      padding-bottom: 0;
     }
 
     button {


### PR DESCRIPTION
## Done
Reduce the max height to allow room top and bottom for mobile browser toolbars

## QA
- Pull the branch
- Run `npm run clean && npm run install && npm run build`
- Then serve with `npm run serve`
- Go to: http://0.0.0.0:8301/
- Click "Revoke cookie manager" _if you do not see the cookie manager_
- Click "Manage your tracking settings"
- Check across large and small screens that there would be enough space at the bottom on Mobile Firefox browsers

Fixes https://github.com/canonical-web-and-design/cookie-policy/issues/92