### PR TITLE
Added google consent mode functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2018,
     "sourceType": "module"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/canonical-web-and-design/cookie-policy.git"
+    "url": "git+https://github.com/canonical/cookie-policy.git"
   },
   "author": "Anthony Dillon <anthony.dillon@canonical.com>",
   "contributors": [
@@ -15,9 +15,9 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/canonical-web-and-design/cookie-policy/issues"
+    "url": "https://github.com/canonical/cookie-policy/issues"
   },
-  "homepage": "https://github.com/canonical-web-and-design/cookie-policy#readme",
+  "homepage": "https://github.com/canonical/cookie-policy#readme",
   "devDependencies": {
     "@babel/core": "7.20.12",
     "@babel/preset-env": "7.20.2",

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -1,4 +1,4 @@
-import { getControlsContent } from "./utils.js";
+import { getControlsContent, getCookie } from "./utils.js";
 
 export class Control {
   constructor(details, container, language) {
@@ -16,13 +16,17 @@ export class Control {
   }
 
   render() {
+    const isChecked = this.cookieIsTrue();
+
     const control = document.createElement("div");
     control.classList.add("u-sv3");
     control.innerHTML = `
       ${
         this.showSwitcher
           ? `<label class="u-float-right p-switch">
-        <input type="checkbox" class="p-switch__input js-${this.id}-switch">
+        <input type="checkbox" class="p-switch__input js-${this.id}-switch" ${
+              isChecked && 'checked=""'
+            }>
         <span class="p-switch__slider"></span>
       </label>`
           : ""
@@ -33,8 +37,21 @@ export class Control {
     this.element = control.querySelector(`.js-${this.id}-switch`);
   }
 
+  cookieIsTrue() {
+    const cookieValue = getCookie("_cookies_accepted");
+
+    // If the cookie value matches the control ID, return true
+    if (cookieValue) {
+      if (cookieValue === this.id || cookieValue === "all") {
+        return true;
+      }
+    }
+    return cookieValue && cookieValue === this.id;
+  }
+
+  // The check should be false by default
   isChecked() {
-    return this.element ? this.element.checked : true;
+    return this.element ? this.element.checked : false;
   }
 
   getId() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,10 @@
-import { Notification } from './notification.js';
-import { Manager } from './manager.js';
-import { preferenceNotSelected, hideSpecified } from './utils.js';
+import { Notification } from "./notification.js";
+import { Manager } from "./manager.js";
+import {
+  preferenceNotSelected,
+  hideSpecified,
+  addGoogleConsentMode,
+} from "./utils.js";
 
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
@@ -12,9 +16,9 @@ export const cookiePolicy = (callback = null) => {
     }
 
     if (cookiePolicyContainer === null) {
-      cookiePolicyContainer = document.createElement('dialog');
-      cookiePolicyContainer.classList.add('cookie-policy');
-      cookiePolicyContainer.setAttribute('open', true);
+      cookiePolicyContainer = document.createElement("dialog");
+      cookiePolicyContainer.classList.add("cookie-policy");
+      cookiePolicyContainer.setAttribute("open", true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -22,7 +26,7 @@ export const cookiePolicy = (callback = null) => {
         close
       );
       notifiation.render(language);
-      document.getElementById('cookie-policy-button-accept').focus();
+      document.getElementById("cookie-policy-button-accept").focus();
     }
   };
 
@@ -32,7 +36,7 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const close = function () {
-    if (typeof callback === 'function') {
+    if (typeof callback === "function") {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
@@ -40,9 +44,11 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const init = function () {
-    const revokeButton = document.querySelector('.js-revoke-cookie-manager');
+    addGoogleConsentMode("essential");
+
+    const revokeButton = document.querySelector(".js-revoke-cookie-manager");
     if (revokeButton) {
-      revokeButton.addEventListener('click', renderNotification);
+      revokeButton.addEventListener("click", renderNotification);
     }
 
     if (preferenceNotSelected() && !hideSpecified()) {
@@ -50,5 +56,5 @@ export const cookiePolicy = (callback = null) => {
     }
   };
 
-  document.addEventListener('DOMContentLoaded', init, false);
+  document.addEventListener("DOMContentLoaded", init, false);
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,10 +1,6 @@
-import { Notification } from "./notification.js";
-import { Manager } from "./manager.js";
-import {
-  preferenceNotSelected,
-  hideSpecified,
-  addGoogleConsentMode,
-} from "./utils.js";
+import { Notification } from './notification.js';
+import { Manager } from './manager.js';
+import { preferenceNotSelected, hideSpecified } from './utils.js';
 
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
@@ -16,9 +12,9 @@ export const cookiePolicy = (callback = null) => {
     }
 
     if (cookiePolicyContainer === null) {
-      cookiePolicyContainer = document.createElement("dialog");
-      cookiePolicyContainer.classList.add("cookie-policy");
-      cookiePolicyContainer.setAttribute("open", true);
+      cookiePolicyContainer = document.createElement('dialog');
+      cookiePolicyContainer.classList.add('cookie-policy');
+      cookiePolicyContainer.setAttribute('open', true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -26,7 +22,7 @@ export const cookiePolicy = (callback = null) => {
         close
       );
       notifiation.render(language);
-      document.getElementById("cookie-policy-button-accept").focus();
+      document.getElementById('cookie-policy-button-accept').focus();
     }
   };
 
@@ -36,7 +32,7 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const close = function () {
-    if (typeof callback === "function") {
+    if (typeof callback === 'function') {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
@@ -44,11 +40,9 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const init = function () {
-    addGoogleConsentMode("essential");
-
-    const revokeButton = document.querySelector(".js-revoke-cookie-manager");
+    const revokeButton = document.querySelector('.js-revoke-cookie-manager');
     if (revokeButton) {
-      revokeButton.addEventListener("click", renderNotification);
+      revokeButton.addEventListener('click', renderNotification);
     }
 
     if (preferenceNotSelected() && !hideSpecified()) {
@@ -56,5 +50,5 @@ export const cookiePolicy = (callback = null) => {
     }
   };
 
-  document.addEventListener("DOMContentLoaded", init, false);
+  document.addEventListener('DOMContentLoaded', init, false);
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,11 @@
-import { Notification } from './notification.js';
-import { Manager } from './manager.js';
-import { preferenceNotSelected, hideSpecified } from './utils.js';
+import { Notification } from "./notification.js";
+import { Manager } from "./manager.js";
+import {
+  preferenceNotSelected,
+  hideSpecified,
+  addGoogleConsentMode,
+  loadConsentFromCookie,
+} from "./utils.js";
 
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
@@ -12,9 +17,9 @@ export const cookiePolicy = (callback = null) => {
     }
 
     if (cookiePolicyContainer === null) {
-      cookiePolicyContainer = document.createElement('dialog');
-      cookiePolicyContainer.classList.add('cookie-policy');
-      cookiePolicyContainer.setAttribute('open', true);
+      cookiePolicyContainer = document.createElement("dialog");
+      cookiePolicyContainer.classList.add("cookie-policy");
+      cookiePolicyContainer.setAttribute("open", true);
       document.body.appendChild(cookiePolicyContainer);
       const notifiation = new Notification(
         cookiePolicyContainer,
@@ -22,7 +27,7 @@ export const cookiePolicy = (callback = null) => {
         close
       );
       notifiation.render(language);
-      document.getElementById('cookie-policy-button-accept').focus();
+      document.getElementById("cookie-policy-button-accept").focus();
     }
   };
 
@@ -32,7 +37,7 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const close = function () {
-    if (typeof callback === 'function') {
+    if (typeof callback === "function") {
       callback();
     }
     document.body.removeChild(cookiePolicyContainer);
@@ -40,9 +45,14 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const init = function () {
-    const revokeButton = document.querySelector('.js-revoke-cookie-manager');
+    // Add the default setup script for Google Consent Mode
+    addGoogleConsentMode();
+    // Load the consent from the cookie, if available
+    loadConsentFromCookie();
+
+    const revokeButton = document.querySelector(".js-revoke-cookie-manager");
     if (revokeButton) {
-      revokeButton.addEventListener('click', renderNotification);
+      revokeButton.addEventListener("click", renderNotification);
     }
 
     if (preferenceNotSelected() && !hideSpecified()) {
@@ -50,5 +60,5 @@ export const cookiePolicy = (callback = null) => {
     }
   };
 
-  document.addEventListener('DOMContentLoaded', init, false);
+  document.addEventListener("DOMContentLoaded", init, false);
 };

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -1,4 +1,9 @@
-import { setCookie, getContent, setGoogleConsentPreferences } from "./utils.js";
+import {
+  setCookie,
+  getContent,
+  setGoogleConsentPreferences,
+  setGoogleConsentFromControls,
+} from "./utils.js";
 import { Control } from "./control.js";
 import { controlsContent } from "./content.js";
 
@@ -64,14 +69,15 @@ export class Manager {
 
     if (this.controlsStore.length === checkedControls.length) {
       setCookie("all");
-      setGoogleConsentPreferences("all");
     } else {
       this.controlsStore.forEach((control) => {
         if (control.isChecked()) {
+          // Note: this overwrites the previous cookie
           setCookie(control.getId());
-          setGoogleConsentPreferences(control.getId());
         }
       });
     }
+
+    setGoogleConsentFromControls(this.controlsStore);
   }
 }

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -1,4 +1,4 @@
-import { setCookie, getContent } from "./utils.js";
+import { setCookie, getContent, setGoogleConsentPreferences } from "./utils.js";
 import { Control } from "./control.js";
 import { controlsContent } from "./content.js";
 
@@ -45,6 +45,7 @@ export class Manager {
   initaliseListeners() {
     this.container.querySelector(".js-close").addEventListener("click", () => {
       setCookie("all");
+      setGoogleConsentPreferences("all");
       this.destroyComponent();
     });
 
@@ -63,10 +64,12 @@ export class Manager {
 
     if (this.controlsStore.length === checkedControls.length) {
       setCookie("all");
+      setGoogleConsentPreferences("all");
     } else {
       this.controlsStore.forEach((control) => {
         if (control.isChecked()) {
           setCookie(control.getId());
+          setGoogleConsentPreferences(control.getId());
         }
       });
     }

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -1,4 +1,4 @@
-import { setCookie, getContent } from "./utils.js";
+import { setCookie, getContent, setGoogleConsentPreferences } from "./utils.js";
 
 export class Notification {
   constructor(container, renderManager, destroyComponent) {
@@ -37,6 +37,7 @@ export class Notification {
   initaliseListeners() {
     this.container.querySelector(".js-close").addEventListener("click", (e) => {
       setCookie("all");
+      setGoogleConsentPreferences("all");
       this.destroyComponent();
     });
     this.container

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,30 +1,30 @@
-import { content } from './content.js';
+import { content } from "./content.js";
 
 export const setCookie = (value) => {
   const d = new Date();
   d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000);
-  const expires = 'expires=' + d.toUTCString();
-  const samesite = 'samesite=lax;';
-  const path = 'path=/;';
+  const expires = "expires=" + d.toUTCString();
+  const samesite = "samesite=lax;";
+  const path = "path=/;";
   document.cookie =
-    '_cookies_accepted=' + value + '; ' + expires + '; ' + samesite + path;
+    "_cookies_accepted=" + value + "; " + expires + "; " + samesite + path;
   if (enabledTracking(value)) {
     pushPageview();
   }
 };
 
 export const getCookie = () => {
-  const toMatch = '_cookies_accepted=';
-  const splitArray = document.cookie.split(';');
-  let cookieValue = '';
-  let currentCookieValue = '';
+  const toMatch = "_cookies_accepted=";
+  const splitArray = document.cookie.split(";");
+  let cookieValue = "";
+  let currentCookieValue = "";
   for (let i = 0; i < splitArray.length; i++) {
     let cookie = splitArray[i];
-    while (cookie.charAt(0) == ' ') {
+    while (cookie.charAt(0) == " ") {
       cookie = cookie.substring(1);
     }
     currentCookieValue = cookie.substring(toMatch.length, cookie.length);
-    if (cookie.indexOf(toMatch) === 0 && currentCookieValue !== 'true') {
+    if (cookie.indexOf(toMatch) === 0 && currentCookieValue !== "true") {
       cookieValue = currentCookieValue;
     }
   }
@@ -32,9 +32,9 @@ export const getCookie = () => {
 };
 
 export const preferenceNotSelected = () => {
-  const cookieValue = getCookie('_cookies_accepted');
+  const cookieValue = getCookie("_cookies_accepted");
   // Skip a value of "true" to override old existing cookies
-  if (cookieValue && cookieValue != 'true') {
+  if (cookieValue && cookieValue != "true") {
     return false;
   } else {
     return true;
@@ -43,9 +43,9 @@ export const preferenceNotSelected = () => {
 
 export const hideSpecified = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  const cpQuery = urlParams.get('cp');
+  const cpQuery = urlParams.get("cp");
 
-  if (cpQuery === 'hide') {
+  if (cpQuery === "hide") {
     return true;
   } else {
     return false;
@@ -56,7 +56,7 @@ export const getContent = (language) => {
   if (content[language]) {
     return content[language];
   } else {
-    return content['default'];
+    return content["default"];
   }
 };
 
@@ -64,18 +64,101 @@ export const getControlsContent = (details, language) => {
   if (details.content[language]) {
     return details.content[language];
   } else {
-    return details.content['default'];
+    return details.content["default"];
+  }
+};
+
+export const addGoogleConsentMode = (mode) => {
+  // Add to head section
+  const consentSetup = `
+  <script>
+    // Define dataLayer and the gtag function.
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Set default consent to 'denied' as a placeholder
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'denied'
+    });
+  </script>`;
+
+  if (document.head.innerHTML) {
+    // Add to the top of the head section to ensure it's before the tag manager script
+    // TODO: Check for existing gtag and only add if it's there
+    // TODO: Check for existing consentSetup and only add if it's not there
+    // TODO: Minify the JS before adding it to the head
+    document.head.innerHTML = consentSetup + document.head.innerHTML;
+  } else {
+    document.head.innerHTML = consentSetup;
+  }
+};
+
+export const setGoogleConsentPreferences = (selectedPreference) => {
+  // 'all' is the default
+  let consentObject = `
+    <script>
+      gtag("consent", "update", {
+        ad_storage: "granted",
+        ad_user_data: "granted",
+        ad_personalization: "granted",
+        analytics_storage: "granted",
+        functionality_storage: "granted",
+        personalization_storage: "granted",
+        security_storage: "granted",
+      })
+    </script>
+  `;
+  if (selectedPreference === "performance") {
+    // 'performance'
+    consentObject = `
+      <script>
+        function consentUpdate() {
+          gtag("consent", "update", {
+            ad_storage: "granted",
+            ad_user_data: "granted",
+            ad_personalization: "granted",
+            analytics_storage: "granted",
+            security_storage: "granted",
+          });
+        };
+      </script>
+    `;
+  } else if (selectedPreference === "functionality") {
+    // 'functionality'
+    consentObject = `
+      <script>
+        function consentUpdate() {
+          gtag('consent', 'update', {
+            'functionality_storage': 'granted',
+            'personalization_storage': 'granted',
+            'security_storage': 'granted'
+          });
+        }
+      </script>
+    `;
+  }
+
+  if (document.head.innerHTML) {
+    // Add to the bottom of the head section to ensure it's after the tag manager script
+    document.head.innerHTML = document.head.innerHTML + consentObject;
+  } else {
+    document.head.innerHTML = consentObject;
   }
 };
 
 const pushPageview = () => {
-  if (typeof dataLayer === 'object') {
-    dataLayer.push({ event: 'pageview' });
+  if (typeof dataLayer === "object") {
+    dataLayer.push({ event: "pageview" });
   }
 };
 
 const enabledTracking = (selectedPreference) => {
-  if (selectedPreference == 'all' || selectedPreference == 'performance') {
+  if (selectedPreference == "all" || selectedPreference == "performance") {
     return true;
   } else {
     return false;


### PR DESCRIPTION
## Done
- Added consent mode initialization on page load
- Set google policy on cookie mode selection

## QA
- Clone the repo
- Build and run the demo 
```bash
$ yarn build
$ yarn serve
```
- Check that before selecting cookie preferences, the `<head>` section of the site has the default `gtag` consent values (all denied)
- Check that after selecting cookie preferences i.e `functionality` or `performance`, the gtag values are updated correctly in the `<head>` section.
  - They should correctly match the `essential`, `functionality` or `performance` selections, as specified [here](https://warthogs.atlassian.net/browse/WD-9265) 
- Test on any site that uses the `cookie-policy`. [canonical.com](https://github.com/canonical/canonical.com) is a good example
  - In the cloned repo, copy the `static/js/modules/cookie-policy/cookie-policy.js` file to static/dist/

## Fixes
[WD-9265](https://warthogs.atlassian.net/browse/WD-9265)

[WD-9265]: https://warthogs.atlassian.net/browse/WD-9265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ