### PR TITLE
Run scripts instead of inserting into head

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -116,22 +116,14 @@ export const addGoogleConsentMode = () => {
     let oldScript = document.getElementById("google-consent-mode");
     oldScript && oldScript.remove();
 
-    // Add to head section
-    const consentSetup = `
-    <script id="google-consent-mode">
-      // Define dataLayer and the gtag function.
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      // Set default consent to 'denied' as a placeholder
-      gtag('consent', 'default', ${JSON.stringify(DEFAULT_CONSENT)});
-    </script>`;
-
-    if (document.head.innerHTML) {
-      // Add to the top of the head section to ensure it's before the tag manager script
-      document.head.innerHTML = consentSetup + document.head.innerHTML;
-    } else {
-      document.head.innerHTML = consentSetup;
+    // Run the script to define gtag
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
     }
+
+    // Set default consent to 'denied' as a placeholder
+    gtag("consent", "default", JSON.stringify(DEFAULT_CONSENT));
   }
 };
 
@@ -151,7 +143,7 @@ export const setGoogleConsentFromControls = (controls) => {
   });
 
   // Insert the script at the bottom of the head section
-  insertConsentScript(updatedConsent);
+  runConsentScript(updatedConsent);
 };
 
 export const setGoogleConsentPreferences = (selectedPreference) => {
@@ -161,7 +153,7 @@ export const setGoogleConsentPreferences = (selectedPreference) => {
   );
 
   // Insert the script at the bottom of the head section
-  insertConsentScript(updatedConsent);
+  runConsentScript(updatedConsent);
 };
 
 const updateConsentPreferences = (consentObject, selectedPreference) => {
@@ -188,23 +180,13 @@ const updateConsentPreferences = (consentObject, selectedPreference) => {
   return updatedConsent;
 };
 
-const insertConsentScript = (consentObject) => {
+const runConsentScript = (consentObject) => {
   // Delete existing script
   let oldScript = document.getElementById("consent-mode-preferences");
   oldScript && oldScript.remove();
 
-  let consentScript = `
-    <script id="consent-mode-preferences">
-      gtag("consent", "update", ${JSON.stringify(consentObject)})
-    </script>
-  `;
-
-  if (document.head.innerHTML) {
-    // Add to the bottom of the head section to ensure it's after the tag manager script
-    document.head.innerHTML = document.head.innerHTML + consentScript;
-  } else {
-    document.head.innerHTML = consentScript;
-  }
+  // Define new script
+  gtag("consent", "update", JSON.stringify(consentObject));
 };
 
 const pushPageview = () => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -104,26 +104,20 @@ export const getControlsContent = (details, language) => {
 export const addGoogleConsentMode = () => {
   let consentAlreadySetup = false;
 
-  // Check for existing gtag, consentSetup before adding the default script
-  for (let item of document.scripts) {
-    if (item.innerHTML.includes("gtag") || item.innerHTML.includes("consent")) {
-      consentAlreadySetup = true;
-    }
-  }
-
-  if (!consentAlreadySetup) {
+  // Check for existing gtag before adding the default script
+  if (!window.gtag) {
     // Delete existing script
     let oldScript = document.getElementById("google-consent-mode");
     oldScript && oldScript.remove();
 
     // Run the script to define gtag
     window.dataLayer = window.dataLayer || [];
-    function gtag() {
+    window.gtag = function gtag() {
       dataLayer.push(arguments);
-    }
+    };
 
     // Set default consent to 'denied' as a placeholder
-    gtag("consent", "default", JSON.stringify(DEFAULT_CONSENT));
+    window.gtag("consent", "default", JSON.stringify(DEFAULT_CONSENT));
   }
 };
 
@@ -185,8 +179,8 @@ const runConsentScript = (consentObject) => {
   let oldScript = document.getElementById("consent-mode-preferences");
   oldScript && oldScript.remove();
 
-  // Define new script
-  gtag("consent", "update", JSON.stringify(consentObject));
+  // Update preferences
+  window.gtag("consent", "update", JSON.stringify(consentObject));
 };
 
 const pushPageview = () => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -102,14 +102,8 @@ export const getControlsContent = (details, language) => {
 };
 
 export const addGoogleConsentMode = () => {
-  let consentAlreadySetup = false;
-
   // Check for existing gtag before adding the default script
   if (!window.gtag) {
-    // Delete existing script
-    let oldScript = document.getElementById("google-consent-mode");
-    oldScript && oldScript.remove();
-
     // Run the script to define gtag
     window.dataLayer = window.dataLayer || [];
     window.gtag = function gtag() {
@@ -175,10 +169,6 @@ const updateConsentPreferences = (consentObject, selectedPreference) => {
 };
 
 const runConsentScript = (consentObject) => {
-  // Delete existing script
-  let oldScript = document.getElementById("consent-mode-preferences");
-  oldScript && oldScript.remove();
-
   // Update preferences
   window.gtag("consent", "update", JSON.stringify(consentObject));
 };


### PR DESCRIPTION
## Done
- Run scripts directly, rather than inserting into the page header

## QA
- Clone the repo
- Build and run the demo

```bash
$ yarn build
$ yarn serve
```

- Before accepting any preferences, output the value of window.dataLayer in the console
- It should contain `{"consent", "default", ...}` 
- After accepting any preferences, output the value of window.dataLayer in the console
- It should contain `{"consent", "update", ...}` 