### PR TITLE
Load consent mode with script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,6 +7,9 @@ import {
   loadConsentFromCookie,
 } from "./utils.js";
 
+// Add Google Consent Mode as soon as the script is loaded
+addGoogleConsentMode();
+
 export const cookiePolicy = (callback = null) => {
   let cookiePolicyContainer = null;
   let language = document.documentElement.lang;
@@ -45,8 +48,6 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const init = function () {
-    // Add the default setup script for Google Consent Mode
-    addGoogleConsentMode();
     // Load the consent from the cookie, if available
     loadConsentFromCookie();
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -111,7 +111,7 @@ export const addGoogleConsentMode = () => {
     };
 
     // Set default consent to 'denied' as a placeholder
-    window.gtag("consent", "default", JSON.stringify(DEFAULT_CONSENT));
+    window.gtag("consent", "default", DEFAULT_CONSENT);
   }
 };
 
@@ -170,7 +170,7 @@ const updateConsentPreferences = (consentObject, selectedPreference) => {
 
 const runConsentScript = (consentObject) => {
   // Update preferences
-  window.gtag("consent", "update", JSON.stringify(consentObject));
+  window.gtag("consent", "update", consentObject);
 };
 
 const pushPageview = () => {


### PR DESCRIPTION
## Done
- Consent mode will now load as soon as the script is loaded, and not wait for the entire DOM to load
- Objects are passed to the `gtag` method raw

## QA
- Clone the repo
- Build and run the demo

```bash
$ yarn build
$ yarn serve
```

- Before accepting any preferences, output the value of window.dataLayer in the console
- It should contain `{"consent", "default", ...}` 
- After accepting any preferences, output the value of window.dataLayer in the console
- It should contain `{"consent", "update", ...}` 