### PR TITLE
fix: Ensure 'essential' cookies are always checked and disable the toggle

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,7 +1,7 @@
 export const controlsContent = [
   {
     id: 'essential',
-    showSwitcher: false,
+    enableSwitcher: false,
     content: {
       default: {
         title: 'Essential',
@@ -22,7 +22,7 @@ export const controlsContent = [
   },
   {
     id: 'performance',
-    showSwitcher: true,
+    enableSwitcher: true,
     content: {
       default: {
         title: 'Performance',
@@ -42,7 +42,7 @@ export const controlsContent = [
   },
   {
     id: 'functionality',
-    showSwitcher: true,
+    enableSwitcher: true,
     content: {
       default: {
         title: 'Functionality',

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -22,14 +22,16 @@ export class Control {
     control.classList.add("u-sv3");
     control.innerHTML = `
       ${
-        this.showSwitcher
-          ? `<label class="u-float-right p-switch">
-        <input type="checkbox" class="p-switch__input js-${this.id}-switch" ${
-              isChecked && 'checked=""'
+        `<label class="u-float-right p-switch">
+          <input type="checkbox" class="p-switch__input js-${this.id}-switch" ${
+              (isChecked || !this.showSwitcher) && 'checked="" '
+            }
+            ${
+              !this.showSwitcher && `disabled="disabled"`
+
             }>
-        <span class="p-switch__slider"></span>
-      </label>`
-          : ""
+          <span class="p-switch__slider"></span>
+        </label>`
       }
       <h4>${this.title}</h4>
       <p>${this.description}</p>`;

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -6,7 +6,7 @@ export class Control {
     this.id = details.id;
     this.title = getControlsContent(details, language).title;
     this.description = getControlsContent(details, language).description;
-    this.showSwitcher = details.showSwitcher;
+    this.enableSwitcher = details.enableSwitcher;
     this.container = container;
     this.element;
 
@@ -24,10 +24,10 @@ export class Control {
       ${
         `<label class="u-float-right p-switch">
           <input type="checkbox" class="p-switch__input js-${this.id}-switch" ${
-              (isChecked || !this.showSwitcher) && 'checked="" '
+              (isChecked || !this.enableSwitcher) && 'checked="" '
             }
             ${
-              !this.showSwitcher && `disabled="disabled"`
+              !this.enableSwitcher && `disabled="disabled"`
 
             }>
           <span class="p-switch__slider"></span>


### PR DESCRIPTION
## Done

This pull request adds a check to the render function to ensure that when the `enableSwitcher` (previously `showSwitcher`)  variable is false, the input element is both checked and disabled.

## QA

Run the project locally
Don't accept any cookies
Check '_cookies_accepted=essential'
Can also check the other combinations (performance, functional. all)

## Issue

Fixes: https://warthogs.atlassian.net/browse/WD-11997