### PR TITLE
Handle central cookie service being down

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1,6 +1,13 @@
 // API Integration Layer for Cookie Policy Session Management
 
-const API_BASE_URL = "http://localhost:8118"; // Change to https://cookies.canonical.com in production
+let API_BASE_URL;
+
+// Set the base URL for the API service
+export const initApi = (apiUrl) => {
+  if (apiUrl) {
+    API_BASE_URL = apiUrl;
+  }
+};
 
 // Build API URL with query parameters
 export const buildApiUrl = (endpoint, params = {}) => {

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -76,7 +76,7 @@ export const postConsentPreferences = async (code, userUuid, preferences) => {
 };
 
 // Redirect to session endpoint
-export const redirectToSession = ({manageConsent, legacyUserId}) => {
+export const redirectToSession = ({ manageConsent, legacyUserId }) => {
   const params = { return_url: window.location.href };
 
   if (manageConsent) {

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -90,3 +90,22 @@ export const redirectToSession = ({manageConsent, legacyUserId}) => {
   const sessionUrl = buildApiUrl("/cookies/session", params);
   window.location.href = sessionUrl;
 };
+
+// Health check for the central service
+export const checkServiceHealth = async () => {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 1000); // 1-second timeout
+
+    const response = await fetch(buildApiUrl("/health"), {
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    return response.ok;
+  } catch (error) {
+    console.error("Cookie service health check failed:", error);
+    return false;
+  }
+};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -18,17 +18,19 @@ import {
   redirectToSession,
   getConsentPreferences,
   checkServiceHealth,
+  initApi,
 } from "./api.js";
 
 // Add Google Consent Mode as soon as the script is loaded
 addGoogleConsentMode();
 
-export const cookiePolicy = (callback = null) => {
+export const cookiePolicy = (apiUrl, callback = null, ) => {
+  let localMode;
   let cookiePolicyContainer = null;
   let language = document.documentElement.lang;
   let initialised = false;
   const sessionParams = extractSessionParameters();
-  let localMode;
+  initApi(apiUrl);
 
   // Handle return from session endpoint
   const handleReturnFromSession = async function () {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -46,7 +46,7 @@ export const cookiePolicy = (callback = null) => {
         setCookiesAcceptedCookie(result.data.preferences.consent);
       }
     }
-    
+
     setUserUuidCookie(user_uuid);
     clearUrlParameters();
   };
@@ -66,6 +66,7 @@ export const cookiePolicy = (callback = null) => {
         renderManager,
         close,
         sessionParams,
+        localMode
       );
       notification.render(language);
       document.getElementById("cookie-policy-button-accept").focus();
@@ -73,7 +74,12 @@ export const cookiePolicy = (callback = null) => {
   };
 
   const renderManager = function () {
-    const manager = new Manager(cookiePolicyContainer, close, sessionParams);
+    const manager = new Manager(
+      cookiePolicyContainer,
+      close,
+      sessionParams,
+      localMode
+    );
     manager.render(language);
   };
 
@@ -94,6 +100,7 @@ export const cookiePolicy = (callback = null) => {
 
     // Then we check if we're returning from a failed redirect session
     if (sessionParams.cookie_redirect_success === "false") {
+      clearUrlParameters();
       setSessionLocalMode();
       localMode = true;
       return false;
@@ -128,7 +135,11 @@ export const cookiePolicy = (callback = null) => {
     if (revokeButton) {
       revokeButton.addEventListener("click", (e) => {
         e.preventDefault();
-        redirectToSession({ manageConsent : true });
+        if (!localMode) {
+          redirectToSession({ manageConsent: true });
+        } else {
+          renderNotification();
+        }
       });
     }
 

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -1,16 +1,14 @@
-import {
-  getContent,
-  storeCookiesPreferences
-} from "./utils.js";
+import { getContent, storeCookiesPreferences } from "./utils.js";
 import { Control } from "./control.js";
 import { controlsContent } from "./content.js";
 
 export class Manager {
-  constructor(container, destroyComponent, sessionParams) {
+  constructor(container, destroyComponent, sessionParams, localMode) {
     this.container = container;
     this.controlsStore = [];
     this.destroyComponent = destroyComponent;
     this.sessionParams = sessionParams;
+    this.localMode = localMode;
   }
 
   getManagerMarkup(language) {
@@ -64,7 +62,11 @@ export class Manager {
   async handleAcceptAll() {
     const preference = "all";
 
-    storeCookiesPreferences(this.sessionParams, preference);
+    storeCookiesPreferences({
+      sessionParams: this.sessionParams,
+      preference,
+      localMode: this.localMode,
+    });
 
     this.destroyComponent();
   }
@@ -84,8 +86,13 @@ export class Manager {
         ? lastCheckedControl.getId()
         : "essential";
     }
-
-    storeCookiesPreferences(this.sessionParams, preference, this.controlsStore);
+    console.log("storing prefs in localMode?", this.localMode);
+    storeCookiesPreferences({
+      sessionParams: this.sessionParams,
+      preference,
+      controlsStore: this.controlsStore,
+      localMode: this.localMode,
+    });
 
     this.destroyComponent();
   }

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -1,19 +1,18 @@
-import {
-  getContent,
-  storeCookiesPreferences
-} from "./utils.js";
+import { getContent, storeCookiesPreferences } from "./utils.js";
 
 export class Notification {
   constructor(
     container,
     renderManager,
     destroyComponent,
-    sessionParams
+    sessionParams,
+    localMode
   ) {
     this.container = container;
     this.renderManager = renderManager;
     this.destroyComponent = destroyComponent;
     this.sessionParams = sessionParams;
+    this.localMode = localMode;
   }
 
   getNotificationMarkup(language) {
@@ -59,7 +58,11 @@ export class Notification {
   async handleAcceptAll() {
     const preference = "all";
 
-    storeCookiesPreferences(this.sessionParams, preference);
+    storeCookiesPreferences({
+      sessionParams: this.sessionParams,
+      preference,
+      localMode: this.localMode,
+    });
 
     this.destroyComponent();
   }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -247,12 +247,12 @@ export const extractSessionParameters = () => {
     user_uuid: getUrlParameter("user_uuid"),
     preferences_unset: getUrlParameter("preferences_unset"),
     action: getUrlParameter("action"),
+    cookie_redirect_success: getUrlParameter("cookie_redirect_success"),
   };
 };
 
-export const isReturnFromSession = (sessionParams) => {
-  const { code, user_uuid } = sessionParams;
-  return !!(code && user_uuid);
+export const isReturnFromSuccessfulSession = (sessionParams) => {
+  return sessionParams.cookie_redirect_success === "true";
 };
 
 export const clearUrlParameters = () => {
@@ -277,3 +277,10 @@ export const redirectNeeded = function () {
 export const getLegacyUserId = () => {
   return getCookieByName("user_id");
 };
+
+export const setSessionLocalMode = (localMode) => {
+  console.warn(
+    "Cookie service is unavailable. Falling back to local mode for this session."
+  );
+  sessionStorage.setItem("cookie_local_mode", "true");
+}


### PR DESCRIPTION
## Done

Sets the users session in 'local mode' if either of the following criteria are met:
1. `cookie_redirect_success` url param is `false`
2. The health check to the central service fails

If in 'local mode' it will not attempt to interact with the central service and store cookies in temporary session instead

## QA

- Check out the latest branch of [cookies.canonical.com ](https://github.com/canonical/cookies.canonical.com) and hard code `validated_return_url` as `http://0.0.0.0:8001` and add `0.0.0.0` to the list of `valid-sites.yml` (`127.0.0.1` for firefox). Run the project with `mise run dev`. Find where `cookie_redirect_success` is set and change it to `false`.
- Check out the ubuntu.com [demo branch](https://github.com/canonical/ubuntu.com/pull/15745) and run the project locally
- Go to 0.0.0.0:8001 and delete any cookie preferences you had (`_cookies_accepted`). Refresh the page
- Select your cookies when prompted, check they appear in the session and the expiry is 'session'. Delete again and now stop running cookies.canonical.com to simulate it being down
- Repeat the above steps

- Check when cookies.canonical.com is running and `cookie_redirect_success` is set to `true`, that cookies are stored centrally and retrieved even after being deleted

## Fixes

Issue https://warthogs.atlassian.net/browse/WD-29820