### PR TITLE
fix: remove global styles from cookie policy stylesheet

### DIFF
--- a/dark/index.html
+++ b/dark/index.html
@@ -17,6 +17,28 @@
       media="screen"
       href="/build/css/cookie-policy.css"
     />
+    <style type="text/css">
+      body {
+        margin: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
+        font-weight: 300;
+        font-family: "Ubuntu variable", Ubuntu, Arial, 'libra sans', sans-serif;
+        line-height: 1.5;
+        background-color: #262626;
+        color: hsl(0, 0%, 100%);
+      }
+      
+      a {
+        color: #69c;
+
+        &:visited {
+          color: #a679d2;
+        }
+      }
+
+    </style>
   </head>
 
   <body class="is-dark">

--- a/index.html
+++ b/index.html
@@ -17,6 +17,17 @@
       media="screen"
       href="/build/css/cookie-policy.css"
     />
+    <style type="text/css">
+      body {
+        margin: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
+        font-weight: 300;
+        font-family: "Ubuntu variable", Ubuntu, Arial, 'libra sans', sans-serif;
+        line-height: 1.5;
+      }
+    </style>
   </head>
 
   <body>

--- a/ja/index.html
+++ b/ja/index.html
@@ -17,6 +17,17 @@
       media="screen"
       href="/build/css/cookie-policy.css"
     />
+    <style type="text/css">
+      body {
+        margin: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
+        font-weight: 300;
+        font-family: "Ubuntu variable", Ubuntu, Arial, 'libra sans', sans-serif;
+        line-height: 1.5;
+      }
+    </style>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/sass/cookie-policy.scss
+++ b/src/sass/cookie-policy.scss
@@ -31,28 +31,3 @@
   /* fix box-sizing that Vanilla sets on html and it doesn't work nested in .cookie-policy */
   box-sizing: border-box;
 }
-
-/* Global styles for all pages */
-body {
-  display: block;
-  font-family: "Ubuntu variable", Ubuntu, Arial, "libra sans", sans-serif;
-  font-weight: 300;
-  height: 100%;
-  line-height: 1.5;
-  margin: 0;
-  width: 100%;
-}
-
-/* Dark theme specific styles */
-.is-dark {
-  background-color: #262626;
-  color: hsl(0deg 0% 100%);
-
-  a {
-    color: #69c;
-
-    &:visited {
-      color: #a679d2;
-    }
-  }
-}

--- a/zh/index.html
+++ b/zh/index.html
@@ -17,6 +17,17 @@
       media="screen"
       href="/build/css/cookie-policy.css"
     />
+    <style type="text/css">
+      body {
+        margin: 0;
+        display: block;
+        width: 100%;
+        height: 100%;
+        font-weight: 300;
+        font-family: "Ubuntu variable", Ubuntu, Arial, 'libra sans', sans-serif;
+        line-height: 1.5;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
# Done
- Remove global styles from cookie policy stylesheet. This is because the custom styles will also be inherited by projects that import cookie policy
- We should keep the body styles for light and dark theme in their specific html files to prevent overwriting styles
- Bump package version to 3.7.1

# QA
- Run this locally by using these steps
```
npm install
npm run build
npm run serve
```
- Go to index page, click on "Revoke cookie manager" and see that styles persist
- Repeat for dark, zh and jp versions