### PR TITLE
fix: apply inline button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+### 3.7.3 [18-11-2025]
+**Updated** Inline button
+- Remove left margin and added bottom margin to override the default inline button styles
+
+### 3.7.2 [18-11-2025]
+**Updated** Global body styles
+- Remove global body styles from the cookie policy stylesheet
+
+### 3.7.0 [17-11-2025]
+**Updated** Cookie popup modernization
+- Implement cookie popup notification banner and accordion manager

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/sass/_patterns-modal.scss
+++ b/src/sass/_patterns-modal.scss
@@ -69,6 +69,8 @@ $breakpoint-small-banner: 320px;
     /* Add margin-left to is-inline button on medium and large screens */
     @media (width > $breakpoint-small-banner) {
       .p-button--link.is-inline {
+        margin-bottom: 1.25rem;
+        margin-left: 0;
         margin-right: $sph--large;
       }
     }

--- a/src/sass/_patterns-modal.scss
+++ b/src/sass/_patterns-modal.scss
@@ -70,7 +70,7 @@ $breakpoint-small-banner: 320px;
     @media (width > $breakpoint-small-banner) {
       .p-button--link.is-inline {
         margin-bottom: 1.25rem;
-        margin-left: 0;
+        margin-left: 0 !important;
         margin-right: $sph--large;
       }
     }


### PR DESCRIPTION
# Done
- Added inline button custom styles to override the default inline button styles when package is imported from another project
- Added `CHANGELOG.md` to track package changes and updates
- Bumped package version

# QA
- Branch off this PR
- Run the project with these commands
```
npm run install
npm run build
npm run serve
```
- Click on the "Revoke cookie manager" button
- Resize the window and see that the padding persists for "Manage your preference" on the notification banner