### PR TITLE
feat: Post cookie preferences to shared cookie service if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.8.0 [21-11-2025]
+**Added** `postUpdatedPreferences()`
+- Posts users cookie preferences to shared cookie service (cookies.canonical.com) providing the application is using the canonicalwebteam.cookies_service package and a connection has been established
+
 ### 3.7.5 [25-11-2025]
 **Updated** Cookie notification banner
 - Enable page interaction with notification banner present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 3.8.0 [21-11-2025]
 **Added** `postUpdatedPreferences()`
-- Posts users cookie preferences to shared cookie service (cookies.canonical.com) providing the application is using the canonicalwebteam.cookies_service package and a connection has been established
+- POSTs users cookie preferences to shared cookie service (cookies.canonical.com) providing the application is using the canonicalwebteam.cookies_service package and a connection has been established
 
 ### 3.7.5 [25-11-2025]
 **Updated** Cookie notification banner

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Essential cookies are always allowed, unless the user turns them off in their br
 
 ### APIs - /cookies/set-preferences
 
-This package will attempt to post users cookie preferences to our shared cookie service (cookies.canonical.com).
-This is handled by a python package, canonicalwebteam.cookies_service, that expose an internal endpoint '/cookies/set-preferences',
-The attempt to post will only be made providing the cookie `_cookies_service_up=1` exists. Applications not using the aforementioned python package will not attempt to post the users preferences.
+This package will attempt to POST users cookie preferences to our shared cookie service (cookies.canonical.com).
+This is handled by a [Python package](https://github.com/canonical/canonicalwebteam.cookie_service), canonicalwebteam.cookies_service, that expose an internal endpoint '/cookies/set-preferences',
+The attempt to POST will only be made providing the cookie `_cookies_service_up=1` exists. Applications not using the aforementioned Python package will not attempt to POST the users preferences.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Essential cookies are always allowed, unless the user turns them off in their br
 | performance | Performance cookies accepted. | - |
 | functionality | Functionality cookies accepted. | - |
 
+### APIs - /cookies/set-preferences
+
+This package will attempt to post users cookie preferences to our shared cookie service (cookies.canonical.com).
+This is handled by a python package, canonicalwebteam.cookies_service, that expose an internal endpoint '/cookies/set-preferences',
+The attempt to post will only be made providing the cookie `_cookies_service_up=1` exists. Applications not using the aforementioned python package will not attempt to post the users preferences.
+
 ## Contributing
 
 If you would like to help improve this project, here is a list of commands to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.7.5",
+  "version": "3.8.0",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1,0 +1,28 @@
+import { getCookie } from "./utils.js";
+
+/*
+ * Posts updated preferences to the shared cookie service endpoint
+ * via the canonicalwebteam.cookie_service package 
+ **/
+export function postUpdatedPreferences() {
+  // Check if cookie service is enabled
+  const cookieServiceUp = getCookie("_cookies_service_up=");
+  if (!cookieServiceUp || cookieServiceUp !== "1") {
+    return;
+  }
+  // Check if preferences cookie exists
+  const cookieAcceptanceValue = getCookie("_cookies_accepted=");
+  if (!cookieAcceptanceValue) {
+    return;
+  }
+  // Post to the backend endpoint
+  // Which then posts to cookies.canonical.com
+  fetch("/cookies/set-preferences", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({"preferences": {"consent": cookieAcceptanceValue}})
+  })
+  .catch(err => console.error("Error sending preferences:", err));
+}

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1,7 +1,7 @@
 import { getCookie } from "./utils.js";
 
 /*
- * Posts updated preferences to the shared cookie service endpoint
+ * POSTs updated preferences to the shared cookie service endpoint
  * via the canonicalwebteam.cookie_service package 
  **/
 export function postUpdatedPreferences() {
@@ -15,8 +15,8 @@ export function postUpdatedPreferences() {
   if (!cookieAcceptanceValue) {
     return;
   }
-  // Post to the backend endpoint
-  // Which then posts to cookies.canonical.com
+  // POST to the backend endpoint
+  // Which then POSTs to cookies.canonical.com
   fetch("/cookies/set-preferences", {
     method: "POST",
     headers: {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -6,7 +6,7 @@ export const controlsContent = [
       default: {
         title: 'Essential',
         description:
-          "Enables the site's core functionality, such as navigation, access to secure areas, video players and payments. The site cannot function properly without these cookies; they can only be disabled by changing your browser preferences.",
+          "Enables the core functionality on our websites, such as navigation, access to secure areas, video players and payments. Our websites cannot function properly without these cookies; they can only be disabled by changing your browser preferences.",
         activeText: 'Always active',
       },
       zh: {
@@ -30,7 +30,7 @@ export const controlsContent = [
       default: {
         title: 'Performance',
         description:
-          'Collects information on site usage, for example, which pages are most frequently visited.',
+          'Collects information on usage on our websites, for example, which pages are most frequently visited.',
       },
       zh: {
         title: '表现性',
@@ -50,7 +50,7 @@ export const controlsContent = [
       default: {
         title: 'Functional',
         description:
-          'Recognizes you when you return to our site. This enables us to personalize content, greet you by name, remember your preferences, and helps you share pages on social networks.',
+          'Recognizes you when you return to our websites. This enables us to personalize content, greet you by name, remember your preferences, and helps you share pages on social networks.',
       },
       zh: {
         title: '功能性',
@@ -71,14 +71,14 @@ export const content = {
     notification: {
       title: 'Your tracker settings',
       body1:
-        'We use cookies and similar methods to recognize visitors and remember preferences. We also use them to measure campaign effectiveness and analyze site traffic. By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties. For further details or to change your consent choices at any time see our <a href="https://canonical.com/legal/data-privacy?cp=hide#cookies">cookie policy</a>.',
+        'We use cookies and similar methods to recognize visitors and remember preferences. We also use them to measure campaign effectiveness and analyze traffic on our websites. By selecting ‘Accept‘, you consent to the use of these methods by us and trusted third parties. For further details or to change your consent choices at any time see our <a href="https://canonical.com/legal/data-privacy?cp=hide#cookies">cookie policy</a>.',
       buttonManage: 'Manage your tracker settings',
       buttonAcceptAll: 'Accept all',
     },
     manager: {
       title: 'Tracking choices',
       body1:
-        'We use cookies to recognize visitors and remember your preferences. They enhance user experience, personalize content and ads, provide social media features, measure campaign effectiveness, and analyze site traffic.',
+        'We use cookies to recognize visitors and remember your preferences. They enhance user experience, personalize content and ads, provide social media features, measure campaign effectiveness, and analyze traffic on our websites.',
       body2:
         'Select the types of trackers you consent to, both by us, and third parties. Learn more at <a href="https://canonical.com/legal/data-privacy?cp=hide#cookies">data privacy: cookie policy</a> - you can change your choices at any time from the footer of the site.',
       acceptAll: 'Accept all',

--- a/src/js/control.js
+++ b/src/js/control.js
@@ -58,7 +58,7 @@ export class Control {
   }
 
   cookieIsTrue() {
-    const cookieValue = getCookie("_cookies_accepted");
+    const cookieValue = getCookie("_cookies_accepted=");
 
     // If the cookie value matches the control ID, return true
     if (cookieValue) {

--- a/src/js/manager.js
+++ b/src/js/manager.js
@@ -1,12 +1,13 @@
 import {
   setCookie,
   getContent,
-  setGoogleConsentPreferences,
   setGoogleConsentFromControls,
   setupAccordion,
+  handleClose,
 } from "./utils.js";
 import { Control } from "./control.js";
 import { controlsContent } from "./content.js";
+import { postUpdatedPreferences } from "./api.js";
 
 export class Manager {
   constructor(container, destroyComponent) {
@@ -66,11 +67,12 @@ export class Manager {
   }
 
   initaliseListeners() {
-    this.container.querySelector(".js-close").addEventListener("click", () => {
-      setCookie("all");
-      setGoogleConsentPreferences("all");
-      this.destroyComponent();
-    });
+    this.container
+      .querySelector(".js-close")
+      .addEventListener("click", () => {
+        handleClose("all", this.destroyComponent)();
+        postUpdatedPreferences();
+      });
     
     // Setup all accordions on the page
     let accordions = document.querySelectorAll('.p-accordion');
@@ -81,6 +83,7 @@ export class Manager {
       .querySelector(".js-save-preferences")
       .addEventListener("click", () => {
         this.savePreferences();
+        postUpdatedPreferences();
         this.destroyComponent();
       });
   }

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -5,6 +5,7 @@ import {
   setCookie,
   setGoogleConsentPreferences,
 } from "./utils.js";
+import { postUpdatedPreferences } from "./api.js";
 
 export class Notification {
   constructor(container, renderManager, destroyComponent) {
@@ -49,7 +50,10 @@ export class Notification {
   initaliseListeners() {
     this.container
       .querySelector(".js-close-all")
-      .addEventListener("click", handleClose("all", this.destroyComponent));
+      .addEventListener("click", () => {
+        handleClose("all", this.destroyComponent)();
+        postUpdatedPreferences();
+      });
 
     this.container
       .querySelector(".js-manage")

--- a/src/js/notification.js
+++ b/src/js/notification.js
@@ -40,7 +40,8 @@ export class Notification {
 
   render(language) {
     this.container.innerHTML = this.getNotificationMarkup(language);
-    if (!getCookie()) {
+    const cookieValue = getCookie("_cookies_accepted=");
+    if (!cookieValue || cookieValue === "unset") {
       setCookie("essential");
       setGoogleConsentPreferences("essential");
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -46,8 +46,7 @@ export const setCookie = (value) => {
   }
 };
 
-export const getCookie = () => {
-  const toMatch = "_cookies_accepted=";
+export const getCookie = (targetCookie) => {
   const splitArray = document.cookie.split(";");
   let cookieValue = "";
   let currentCookieValue = "";
@@ -56,8 +55,8 @@ export const getCookie = () => {
     while (cookie.charAt(0) == " ") {
       cookie = cookie.substring(1);
     }
-    currentCookieValue = cookie.substring(toMatch.length, cookie.length);
-    if (cookie.indexOf(toMatch) === 0 && currentCookieValue !== "true") {
+    currentCookieValue = cookie.substring(targetCookie.length, cookie.length);
+    if (cookie.indexOf(targetCookie) === 0 && currentCookieValue !== "true") {
       cookieValue = currentCookieValue;
     }
   }
@@ -65,7 +64,7 @@ export const getCookie = () => {
 };
 
 export const preferenceNotSelected = () => {
-  const cookieValue = getCookie("_cookies_accepted");
+  const cookieValue = getCookie("_cookies_accepted=");
   // Skip a value of "true" and "unset" to override old existing cookies
   if (cookieValue && cookieValue != "true" && cookieValue != "unset") {
     return false;
@@ -116,7 +115,7 @@ export const addGoogleConsentMode = () => {
 };
 
 export const loadConsentFromCookie = () => {
-  const cookieValue = getCookie("_cookies_accepted");
+  const cookieValue = getCookie("_cookies_accepted=");
   cookieValue && setGoogleConsentPreferences(cookieValue);
 };
 
@@ -238,6 +237,7 @@ export const setupAccordion = (accordionContainer) => {
 
 /**
  * Handles closing the notification/modal with a specific preference.
+ * If available, posts the preferences to shared cookie service.
  * @param {string} preference - The cookie preference (e.g., "essential" or "all").
  * @param {Function} destroyComponent - The function to destroy the component.
  * @returns {Function} - The event handler function.

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -237,7 +237,7 @@ export const setupAccordion = (accordionContainer) => {
 
 /**
  * Handles closing the notification/modal with a specific preference.
- * If available, posts the preferences to shared cookie service.
+ * If available, POSTs the preferences to shared cookie service.
  * @param {string} preference - The cookie preference (e.g., "essential" or "all").
  * @param {Function} destroyComponent - The function to destroy the component.
  * @returns {Function} - The event handler function.

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz"
   integrity sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.0.0-0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.12.0", "@babel/core@^7.13.0", "@babel/core@^7.4.0-0", "@babel/core@7.20.12":
+"@babel/core@7.20.12":
   version "7.20.12"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz"
   integrity sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==
@@ -933,7 +933,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -946,10 +946,70 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@parcel/watcher-android-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
+  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+
 "@parcel/watcher-darwin-arm64@2.5.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz"
   integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+
+"@parcel/watcher-darwin-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
+  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+
+"@parcel/watcher-freebsd-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
+  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+
+"@parcel/watcher-linux-arm-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
+  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+
+"@parcel/watcher-linux-arm-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
+  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
+  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+
+"@parcel/watcher-linux-arm64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
+  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+
+"@parcel/watcher-linux-x64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
+"@parcel/watcher-win32-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
+  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+
+"@parcel/watcher-win32-ia32@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
+  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
+
+"@parcel/watcher-win32-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
+  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.1"
@@ -1031,7 +1091,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.8.2, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -1160,7 +1220,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.2, "browserslist@>= 4.21.0":
+browserslist@^4.24.0, browserslist@^4.24.2:
   version "4.24.2"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz"
   integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
@@ -1418,7 +1478,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@>=5, eslint@8.32.0:
+eslint@8.32.0:
   version "8.32.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz"
   integrity sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==
@@ -1617,7 +1677,7 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -1642,7 +1702,7 @@ get-stream@^5.0.0:
   dependencies:
     pump "^3.0.0"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1655,13 +1715,6 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob@^7.1.3:
   version "7.2.3"
@@ -1815,7 +1868,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2311,17 +2364,7 @@ picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -2364,7 +2407,7 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.3.11, postcss@^8.3.3, postcss@^8.4.20:
+postcss@^8.3.11, postcss@^8.4.20:
   version "8.4.49"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz"
   integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
@@ -2378,7 +2421,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@>=2.0.0, prettier@2.8.3:
+prettier@2.8.3:
   version "2.8.3"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
@@ -2567,7 +2610,7 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^1.20.0||^2.0.0||^3.0.0, rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, "rollup@^2.x || ^3.x", rollup@3.10.0:
+rollup@3.10.0:
   version "3.10.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz"
   integrity sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==
@@ -2586,7 +2629,7 @@ safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-sass@^1.79.0, sass@1.89.2:
+sass@1.89.2:
   version "1.89.2"
   resolved "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz"
   integrity sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==
@@ -2597,7 +2640,7 @@ sass@^1.79.0, sass@1.89.2:
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
 
-semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.7.1:
   version "5.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -2616,11 +2659,6 @@ semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
-"semver@2 || 3 || 4 || 5":
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 serialize-javascript@^6.0.0:
   version "6.0.2"
@@ -2672,7 +2710,7 @@ smob@^0.0.6:
   resolved "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz"
   integrity sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==
 
-source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -2721,13 +2759,6 @@ specificity@^0.4.1:
   resolved "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -2736,6 +2767,13 @@ string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.1:
   version "6.0.1"
@@ -2786,7 +2824,7 @@ stylelint-order@6.0.1:
     postcss "^8.4.20"
     postcss-sorting "^8.0.1"
 
-stylelint@^14.0.0, stylelint@14.2.0:
+stylelint@14.2.0:
   version "14.2.0"
   resolved "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz"
   integrity sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==


### PR DESCRIPTION
## Done

- Adds a new function `postUpdatedPreferences` that is triggered after a user selects their cookie preferences and posts the data to the shared cookie service
- Updates changelog and readme

Flyby:
- Use generic `handleClose` function where possible

## QA

- Check out [this branch](https://github.com/canonical/canonical.com/pull/2052) locally and run the project (search in BitWarden for cookies.canonical.com for keys you will need)
- Select you cookies and check they are stored correctly
- Delete the cookie manually and refresh
- The same cookie should be retrieved, confirming that the post request was successful

## Issue

Fixes https://warthogs.atlassian.net/browse/WD-31462
