### PR TITLE
chore: Update cn consent language to reflect cross-domain cookie support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.8.1 [28-11-2025]
+**Updated** CN consent language
+- Updates language used for Chinese version of the consent modal, to reflect our use of cross-domain cookies.
+
 ### 3.8.0 [21-11-2025]
 **Added** `postUpdatedPreferences()`
 - POSTs users cookie preferences to shared cookie service (cookies.canonical.com) providing the application is using the canonicalwebteam.cookies_service package and a connection has been established

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/cookie-policy",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "A script and style sheet that displays a cookie policy notification",
   "main": "build/js/module.js",
   "iife": "build/js/cookie-policy.js",

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -90,7 +90,7 @@ export const content = {
     notification: {
       title: '您的追踪器设置',
       body1:
-        '我们使用cookie和相似的方法来识别访问者和记住偏好设置。我们也用它们来衡量活动的效果和网站流量分析。选择”接受“，您同意我们和受信的第三方来使用这些方式。更多内容或者随时地变更您的同意选择，请点击我们的<a href="https://canonical.com/legal/data-privacy?cp=hide#cookies"> cookie 策略</a>。',
+        '我们使用cookie和相似的方法来识别访问者和记住访问者的偏好设置, 并用来衡量活动的效果和分析 Canonical 旗下所有网站的流量。选择”接受“，您同意我们和受信的第三方来使用这些资料。更多细节或者随时变更您的选择，请阅读我们的<a href="https://canonical.com/legal/data-privacy?cp=hide#cookies"> cookie 策略</a>。',
       buttonManage: '管理您的追踪器设置',
       buttonAcceptAll: '接受',
     },

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -90,7 +90,7 @@ export const content = {
     notification: {
       title: '您的追踪器设置',
       body1:
-        '我们使用cookie和相似的方法来识别访问者和记住访问者的偏好设置, 并用来衡量活动的效果和分析 Canonical 旗下所有网站的流量。选择”接受“，您同意我们和受信的第三方来使用这些资料。更多细节或者随时变更您的选择，请阅读我们的<a href="https://canonical.com/legal/data-privacy?cp=hide#cookies"> cookie 策略</a>。',
+        '我们使用 cookie 和相似的方法来识别访问者和记住访问者的偏好设置，并用来衡量活动的效果和分析 Canonical 旗下所有网站的流量。选择”接受“，您同意我们和受信的第三方来使用这些资料。更多细节或者随时变更您的选择，请阅读我们的<a href="https://canonical.com/legal/data-privacy?cp=hide#cookies"> cookie 策略</a>。',
       buttonManage: '管理您的追踪器设置',
       buttonAcceptAll: '接受',
     },


### PR DESCRIPTION
## Done

- Update cn consent language to reflect cross-domain cookie support

## QA

- Check out this branch locally and run the project
- From the demo page open the Chinese modal
- Check the language updates match that from the [copydoc](https://docs.google.com/document/d/11Xe0-2zoHI0O51gid-2FSE3YdzUOFPftRGBly_HXqLc/edit?tab=t.0) (ONLY CHINESE)

## Issue

Fixes https://warthogs.atlassian.net/browse/WD-31640